### PR TITLE
[#39] 개발용 auth-service 도커설정 추가

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17-alpine
+
+WORKDIR /usr/src/app
+
+ARG JAR_PATH=./build/libs
+
+COPY ${JAR_PATH}/demo-0.0.1-SNAPSHOT.jar ${JAR_PATH}/demo-0.0.1-SNAPSHOT.jar
+
+CMD ["java","-jar","./build/libs/demo-0.0.1-SNAPSHOT.jar"]

--- a/auth-service/README.MD
+++ b/auth-service/README.MD
@@ -1,0 +1,20 @@
+## AUTH-SERVICE DOCKER 사용법
+
+### 1. gradle 8.2 version 설치
+
+### 2. yml파일 작성
+
+https://github.com/Side-Project-Planting/Backend/pull/11
+참고
+
+### 3. jar 파일 빌드
+
+auth-service 경로에서 실행
+> ./gradlew build -x test
+
+### 4. Docker 실행
+
+auth-service 경로에서 실행
+> docker-compose up
+
+

--- a/auth-service/docker-compose.yml
+++ b/auth-service/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_DATABASE: temp230928 # 생성할 데이터베이스 이름 설정.
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
       - "3306:3306"
 

--- a/auth-service/docker-compose.yml
+++ b/auth-service/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: temp230928 # 생성할 데이터베이스 이름 설정.
+    ports:
+      - "3306:3306"
+
+  auth-service:
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8443:8443"
+    depends_on:
+      - mysql


### PR DESCRIPTION
📌 Description
- auth-service만 사용하기 위한 도커라이징 입니다.
- mysql의 사용을 용이하게 하기 위해 docker-compose로 함께 말아주었습니다
- 추후 전체 서비스 연동시 변경될 수 있습니다.
- README에 사용법 업로드했습니다. 
⚠️ 주의사항
- auth service 의 포트를 8443으로 바꾸었습니다. 
- 노션에 환경 설정 정보를 업로드했습니다.