### PR TITLE
[#12] API Gateway에 JWT 필터 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### Custom ###
+/**/application-local.yml
+
 .gradle
 gradle
 !gradle/wrapper/gradle-wrapper.jar

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -1,9 +1,18 @@
-
 dependencies {
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.projectreactor:reactor-test'
 }

--- a/gateway-service/src/main/java/com/example/gatewayservice/GatewayServiceApplication.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/GatewayServiceApplication.java
@@ -9,5 +9,4 @@ public class GatewayServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(GatewayServiceApplication.class, args);
     }
-
 }

--- a/gateway-service/src/main/java/com/example/gatewayservice/config/FilterConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/config/FilterConfig.java
@@ -1,0 +1,23 @@
+package com.example.gatewayservice.config;
+
+import com.example.gatewayservice.filter.AuthenticationFilter;
+import com.example.gatewayservice.jwt.JwtValidator;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+    private final JwtValidator jwtValidator;
+
+    @Bean
+    @Order(-1)
+    public AuthenticationFilter authenticationFilter() {
+        return new AuthenticationFilter(jwtValidator);
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
@@ -1,0 +1,22 @@
+package com.example.gatewayservice.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+            .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+            .build();
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/filter/AuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/filter/AuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.example.gatewayservice.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.example.gatewayservice.jwt.JwtValidator;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+// TODO 테스트 코드가 필요합니다. 해당 부분은 통합테스트가 필요하다 느껴져, 하위 서버를 만든 뒤 테스트를 진행할 생각입니다.
+@RequiredArgsConstructor
+public class AuthenticationFilter implements GlobalFilter {
+
+    private final JwtValidator jwtValidator;
+
+    /**
+     * 요청에 Bearer + JWT 토큰이 함께 들어온 경우에는, 토큰을 검증한 뒤 응답에 X-User-Id : subject 헤더를 추가한 뒤 다음 필터를 실행한다.
+     * 만약 토큰이 존재하지 않았다면 다음 필터를 실행한다. 이 경우 사용자가 임의로 값을 설정할 수 없도록 X-User-Id를 제거하는 과정을 갖는다.
+     */
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String tokenBeforeProcessing = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (tokenBeforeProcessing != null && tokenBeforeProcessing.startsWith("Bearer ")) {
+            String token = tokenBeforeProcessing.substring(7);
+            if (!jwtValidator.validateToken(token)) {
+                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                return Mono.empty();
+            }
+
+            String subject = jwtValidator.getSubject(token);
+            ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+                .header("X-User-Id", subject)
+                .build();
+
+            return chain.filter(exchange.mutate().request(mutatedRequest).build());
+        }
+
+        ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+            .headers(headers -> headers.remove("X-User-Id"))
+            .build();
+        return chain.filter(exchange.mutate().request(mutatedRequest).build());
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtProperties.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtProperties.java
@@ -1,0 +1,15 @@
+package com.example.gatewayservice.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String secret;
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtValidator.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtValidator.java
@@ -1,0 +1,49 @@
+package com.example.gatewayservice.jwt;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtValidator {
+    private final JwtParser parser;
+
+    @Autowired
+    public JwtValidator(JwtProperties properties) {
+        byte[] keyBytes = Decoders.BASE64.decode(properties.getSecret());
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+        this.parser = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build();
+    }
+    public boolean validateToken(String token) {
+        return !isTokenExpired(token);
+    }
+
+
+    private boolean isTokenExpired(String token) {
+        try {
+            getExpirationDateFromToken(token);
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
+    private Claims getAllClaimsFromToken(String token) {
+        return parser.parseClaimsJws(token).getBody();
+    }
+
+    private Date getExpirationDateFromToken(String token) {
+        return getAllClaimsFromToken(token).getExpiration();
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtValidator.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/jwt/JwtValidator.java
@@ -29,6 +29,10 @@ public class JwtValidator {
         return !isTokenExpired(token);
     }
 
+    public String getSubject(String token) {
+        Claims claims = getAllClaimsFromToken(token);
+        return claims.getSubject();
+    }
 
     private boolean isTokenExpired(String token) {
         try {
@@ -39,11 +43,12 @@ public class JwtValidator {
         }
     }
 
+    private Date getExpirationDateFromToken(String token) {
+        return getAllClaimsFromToken(token).getExpiration();
+    }
+
     private Claims getAllClaimsFromToken(String token) {
         return parser.parseClaimsJws(token).getBody();
     }
 
-    private Date getExpirationDateFromToken(String token) {
-        return getAllClaimsFromToken(token).getExpiration();
-    }
 }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8000
 
 spring:
+  profiles:
+    active: local
   application:
     name: gateway-service
   rabbitmq:

--- a/gateway-service/src/test/java/com/example/gatewayservice/jwt/JwtPropertiesTest.java
+++ b/gateway-service/src/test/java/com/example/gatewayservice/jwt/JwtPropertiesTest.java
@@ -1,0 +1,21 @@
+package com.example.gatewayservice.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("Jwt Properties 파일이 잘 초기화되었는지 확인하는 테스트")
+class JwtPropertiesTest {
+    @Autowired
+    JwtProperties jwtProperties;
+
+    @Test
+    @DisplayName("Jwt 프로퍼티는 secret을 반환할 수 있다")
+    void canReturnSecret() {
+        assertThat(jwtProperties.getSecret()).isNotBlank();
+    }
+}

--- a/gateway-service/src/test/java/com/example/gatewayservice/jwt/JwtValidatorTest.java
+++ b/gateway-service/src/test/java/com/example/gatewayservice/jwt/JwtValidatorTest.java
@@ -1,0 +1,68 @@
+package com.example.gatewayservice.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@SpringBootTest
+class JwtValidatorTest {
+    @Autowired
+    JwtValidator jwtValidator;
+
+    @Autowired
+    JwtProperties properties;
+
+    Key key;
+
+    @BeforeEach
+    void setup() {
+        byte[] keyBytes = Decoders.BASE64.decode(properties.getSecret());
+        key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    @Test
+    @DisplayName("토큰이 기한이 만료되지 않으면 true를 반환한다")
+    void validateToken() {
+        // given
+        LocalDateTime expired = LocalDateTime.of(3099, 1, 1, 0, 0);
+        String token = makeToken("1L", expired);
+
+        // when & then
+        assertThat(jwtValidator.validateToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("토큰이 기한이 만료되었으면 false를 반환한다")
+    void validateExpiredToken() {
+        // given
+        LocalDateTime expired = LocalDateTime.of(1999, 1, 1, 0, 0);
+        String token = makeToken("1L", expired);
+
+        // when & then
+        assertThat(jwtValidator.validateToken(token)).isFalse();
+    }
+
+    private String makeToken(String subject, LocalDateTime expiredDateTime) {
+        Date expiredDate = Date.from(expiredDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        return Jwts.builder()
+            .setSubject(subject)
+            .setExpiration(expiredDate)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+}


### PR DESCRIPTION
📌 Description
JWT 토큰이 적절한지 검사한 뒤, 적절하다면 헤더 `X-User-Id: 토큰에서 꺼낸 subject`를 추가합니다. 이후 해당 요청은 하위 MSA 서버로 전달됩니다.
`AuthenticationFilter`는 모든 요청에 대해 JWT Token을 꺼내 확인합니다.

해당 기능을 구현하면서 다음과 같은 고민들을 했습니다.

**고민 1: 모든 요청에 대해 JWT 토큰을 확인하는 게 맞을까**
인증/인가가 필요할 때만 해당 Filter를 동작시킬까 고민했지만, Api Gateway 관점에서 바라봤을 때 좋은 설계가 아니라는 생각을 했습니다.
login이 필요한 요청들을 구별하려면 어딘가에 URI들을 전부 저장해둬야 하기 때문에 관리에 있어서 좋지 않다는 생각을 했습니다.
어차피 인증/인가가 필요한 기능이라면 하위 서버에서 401 오류를 반환합니다. 그래서 그냥 모든 요청에 대해 Filter를 타도록 만들었습니다.

**고민 2: JWT 토큰을 검증하는 로직을 Api Gateway에서 하는 게 맞을까(Auth Server가 있음에도 불구하고)**
초기 설계에서는 Api Gateway의 필터가 Auth Server를 호출하여 토큰을 검증하도록 만들려고 했습니다.
하지만 매우 빈번하게 일어나는 요청인데 네트워크를 계속 타는 게 성능상 문제가 있을거라 생각했습니다.
따라서 토큰을 검증하는 로직은 Gateway에서 일어나도록 만들었습니다.
이 방식을 사용하면 JWT 토큰의 Secret을 관리하는 포인트가 두 군데가 된다는 문제가 있습니다. 하지만 이 문제는 추후 Configuration Server를 도입하기 때문에 문제가 되지 않는다 생각합니다.

**TMI**
Webflux가 생각했던 것 이상으로 복잡합니다. 코드를 작성하는 패러다임 자체가 달라져 단순하게 사용하는 수준으로 학습하는 게 쉽지 않습니다 ㅠㅠ... 일단 급한 불은 껐으니까 나중에 시간 될 때 같이 학습하면 좋을 거 같아요.

⚠️ 주의사항
- 10월 7일 기준 AuthenticationFilter에 대한 테스트를 작성하지 않았습니다. 나중에 하위 MSA 서버 만든 다음에 테스트를 작성할게요. 
- API 요청을 보낼 때, 실제 MSA 서버를 띄워두고 요청을 보내지 않으면 필터가 동작하지 않습니다. ~이걸몰라서 한참 헤맸네요~

closes #12 
