### PR TITLE
[#13] 플랜 서비스 엔티티 매핑

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,13 +80,10 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,22 +130,29 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -193,6 +197,10 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
 # Collect all arguments for the java command;
 #   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
 #     shell script including quotes and variable substitutions, so put them in
@@ -204,6 +212,12 @@ set -- \
         -classpath "$CLASSPATH" \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
+
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
+fi
 
 # Use "xargs" to parse quoted args.
 #

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,8 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +41,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,13 +76,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/plan-service/build.gradle
+++ b/plan-service/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/plan-service/src/main/java/com/example/planservice/PlanServiceApplication.java
+++ b/plan-service/src/main/java/com/example/planservice/PlanServiceApplication.java
@@ -1,0 +1,13 @@
+package com.example.planservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PlanServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PlanServiceApplication.class, args);
+    }
+
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/BaseEntity.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.example.planservice.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
@@ -11,8 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "comments")
 public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
@@ -5,6 +5,7 @@ import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.task.Task;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,11 +19,11 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id")
     private Task task;
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/comment/Comment.java
@@ -1,0 +1,28 @@
+package com.example.planservice.domain.comment;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.task.Task;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private Member writer;
+
+    @ManyToOne
+    @JoinColumn(name = "task_id")
+    private Task task;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -1,0 +1,25 @@
+package com.example.planservice.domain.label;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.plan.Plan;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Label extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "label_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    private String name;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "labels")
 public class Label extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -4,6 +4,7 @@ import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.plan.Plan;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,7 +18,7 @@ public class Label extends BaseEntity {
     @Column(name = "label_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
 

--- a/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "members")
 @Where(clause = "is_deleted = false")
 public class Member extends BaseEntity {
     @Id

--- a/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
@@ -1,0 +1,35 @@
+package com.example.planservice.domain.member;
+
+import org.hibernate.annotations.Where;
+
+import com.example.planservice.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+@Where(clause = "is_deleted = false")
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String profileImgUri;
+
+    private String name;
+
+    private String email;
+
+    private boolean receiveEmails;
+
+    @Enumerated(value = EnumType.STRING)
+    private Role role;
+
+    private boolean isDeleted;
+
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/member/Role.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/Role.java
@@ -1,0 +1,12 @@
+package com.example.planservice.domain.member;
+
+public enum Role {
+    ADMIN("관리자"),
+    USER("일반 사용자");
+
+    private final String text;
+
+    Role(String text) {
+        this.text = text;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
@@ -11,8 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "members_of_plan")
 public class MemberOfPlan extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
@@ -1,4 +1,4 @@
-package com.example.planservice.domain.memberofteam;
+package com.example.planservice.domain.memberofplan;
 
 import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.member.Member;
@@ -13,10 +13,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class MemberOfTeam extends BaseEntity {
+public class MemberOfPlan extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_of_team_id")
+    @Column(name = "member_of_plan_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofteam/MemberOfTeam.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofteam/MemberOfTeam.java
@@ -5,6 +5,7 @@ import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.plan.Plan;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,11 +19,11 @@ public class MemberOfTeam extends BaseEntity {
     @Column(name = "member_of_team_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofteam/MemberOfTeam.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofteam/MemberOfTeam.java
@@ -1,0 +1,28 @@
+package com.example.planservice.domain.memberofteam;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.plan.Plan;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class MemberOfTeam extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_of_team_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -12,8 +12,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "plans")
 @Where(clause = "is_deleted = false")
 public class Plan extends BaseEntity {
     @Id

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -6,6 +6,7 @@ import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,7 +21,7 @@ public class Plan extends BaseEntity {
     @Column(name = "plan_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id")
     private Member owner;
 

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -1,0 +1,38 @@
+package com.example.planservice.domain.plan;
+
+import org.hibernate.annotations.Where;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+@Where(clause = "is_deleted = false")
+public class Plan extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "owner_id")
+    private Member owner;
+
+    private String title;
+
+    private String intro;
+
+    private boolean isPublic;
+
+    private int starCnt;
+
+    private int viewCnt;
+
+    private boolean isDeleted;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
@@ -11,8 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "stars")
 public class Star extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
@@ -1,0 +1,28 @@
+package com.example.planservice.domain.star;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.plan.Plan;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Star extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "star_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/star/Star.java
@@ -5,6 +5,7 @@ import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.plan.Plan;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,11 +19,11 @@ public class Star extends BaseEntity {
     @Column(name = "star_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -4,6 +4,7 @@ import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.plan.Plan;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,7 +18,7 @@ public class Tab extends BaseEntity {
     @Column(name = "tab_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
 

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -1,0 +1,27 @@
+package com.example.planservice.domain.tab;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.plan.Plan;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Tab extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tab_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    private String name;
+
+    private int order;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "tabs")
 public class Tab extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "labels_of_task")
 public class LabelOfTask extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
@@ -1,0 +1,27 @@
+package com.example.planservice.domain.task;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.label.Label;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class LabelOfTask extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "label_of_task_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @ManyToOne
+    @JoinColumn(name = "label_id")
+    private Label label;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
@@ -4,6 +4,7 @@ import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.label.Label;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,11 +18,11 @@ public class LabelOfTask extends BaseEntity {
     @Column(name = "label_of_task_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id")
     private Task task;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "label_id")
     private Label label;
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -15,8 +15,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "tasks")
 @Where(clause = "is_deleted = false")
 public class Task extends BaseEntity {
     @Id

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -1,0 +1,47 @@
+package com.example.planservice.domain.task;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Where;
+
+import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.tab.Tab;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+@Where(clause = "is_deleted = false")
+public class Task extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "tab_id")
+    private Tab tab;
+
+    @ManyToOne
+    @JoinColumn(name = "manager_id")
+    private Member manager;
+
+    @ManyToOne
+    @JoinColumn(name = "writer_id")
+    private Member writer;
+
+    private String name;
+
+    private String description;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private boolean isDeleted;
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -9,6 +9,7 @@ import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.tab.Tab;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,15 +24,15 @@ public class Task extends BaseEntity {
     @Column(name = "task_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tab_id")
     private Tab tab;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id")
     private Member manager;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
 

--- a/plan-service/src/main/resources/application.yml
+++ b/plan-service/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local

--- a/plan-service/src/test/java/com/example/planservice/PlanServiceApplicationTests.java
+++ b/plan-service/src/test/java/com/example/planservice/PlanServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.planservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PlanServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'planting'
-include 'auth-service','config-service', 'eureka-service', 'gateway-service'
+include 'auth-service','config-service', 'eureka-service', 'gateway-service', 'plan-service'
 


### PR DESCRIPTION
플랜 서비스의 ERD를 JPA Entity로 매핑했습니다.

단순 단방향 매핑만 해뒀습니다.
Base 파일이 있어야 충돌이 일어났을 때 해결이 쉽기 때문입니다.

각 관계는 각자 맡은 작업을 하면서 필요에 의해 연결할 생각입니다.


⚠️ 주의사항


1. Table 이름은 Plan_Member가 좋을까요, Member_Of_Plan이 좋을까요?
먼저 관계테이블에 해당되는 엔티티에 대해 MemberOfPlan, LabelOfTask 라는 이름으로 객체를 구현했습니다. 
객체라는 관점에서 바라봤을 때, 이런 이름으로 구현하는 게 훨씬 가독성이 좋다 생각해 이렇게 구현했는데요.
그런데 테이블 이름은 어떤 게 더 좋을지 감이 잘 오지 않아서요. 어떻게 하는 게 좋아 보이시나요?
<img width="365" alt="스크린샷 2023-10-10 오후 8 18 30" src="https://github.com/Side-Project-Planting/Backend/assets/67636607/2967b505-8997-4fcf-9141-bac50c5039a9">

+ 객체 관점에서는 LabelOfTask 이런 방식이 LabelTask보다 가독성이 좋다 생각하는데 이 의견에는 동의하시나요?


2. 저희 Table 명 복수로 하기로 했었나요? (ex. Members)
우선 ERD 상에 단수로 나와있어 단수로 매핑했는데, 복수로 하기로 했던 거 같아서요.

4. 원래 연관관계가 깊은 애들끼리 같은 디렉토리로 묶어주려 했습니다. 예를 들면 Plan과 Tab이라는 객체가 있겠네요. 그런데 지금 단계에서 판단하는 것보다 코드를 작성하면서 연관이 깊은 객체들을 묶어주는 게 좋을 거 같아 모든 엔티티마다 디렉토리를 나눠줬습니다.
<img width="198" alt="스크린샷 2023-10-10 오후 8 15 22" src="https://github.com/Side-Project-Planting/Backend/assets/67636607/4cf549de-a06d-432b-89a8-be8cf51ad99c">



close #13 