### PR TITLE
[#24] 탭 생성 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -3,10 +3,15 @@ package com.example.planservice.application;
 import org.springframework.stereotype.Service;
 
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import com.example.planservice.presentation.dto.response.TabRetrieveResponse;
 
 @Service
 public class TabService {
     public Long create(Long userId, TabCreateRequest request) {
+        return null;
+    }
+
+    public TabRetrieveResponse retrieve(Long id) {
         return null;
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -1,0 +1,12 @@
+package com.example.planservice.application;
+
+import org.springframework.stereotype.Service;
+
+import com.example.planservice.presentation.dto.request.TabCreateRequest;
+
+@Service
+public class TabService {
+    public Long create(Long userId, TabCreateRequest request) {
+        return null;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -11,7 +11,7 @@ public class TabService {
         return null;
     }
 
-    public TabRetrieveResponse retrieve(Long id) {
+    public TabRetrieveResponse retrieve(Long id, Long userId) {
         return null;
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -49,20 +49,21 @@ public class TabService {
             throw new ApiException(ErrorCode.TAB_NAME_DUPLICATE);
         }
 
-        Optional<Integer> maxSequenceOpt = tabsOfPlan.stream()
-            .map(Tab::getSequence)
-            .max(Integer::compareTo);
-
-        int maxSequence = 0;
-        if (maxSequenceOpt.isPresent()) {
-            maxSequence = maxSequenceOpt.get();
-        }
-
         Tab tab = Tab.builder()
             .name(request.getName())
             .plan(plan)
-            .sequence(maxSequence + 1)
             .build();
+
+        // tabsOfPlan에서 가장 오른쪽에 있는 애를 찾는다
+        Optional<Tab> lastOpt = tabsOfPlan.stream()
+            .filter(each -> each.getNext() == null)
+            .findAny();
+
+        if (lastOpt.isPresent()) {
+            Tab last = lastOpt.get();
+            last.connect(tab);
+        }
+
         Tab savedTab = tabRepository.save(tab);
         return savedTab.getId();
     }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,11 +55,7 @@ public class TabService {
             .plan(plan)
             .build();
 
-        // tabsOfPlan에서 가장 오른쪽에 있는 애를 찾는다
-        Optional<Tab> lastOpt = tabsOfPlan.stream()
-            .filter(each -> each.getNext() == null)
-            .findAny();
-
+        Optional<Tab> lastOpt = findLastTab(tabsOfPlan);
         if (lastOpt.isPresent()) {
             Tab last = lastOpt.get();
             last.connect(tab);
@@ -66,6 +63,20 @@ public class TabService {
 
         Tab savedTab = tabRepository.save(tab);
         return savedTab.getId();
+    }
+
+    @NotNull
+    private Optional<Tab> findLastTab(List<Tab> tabsOfPlan) {
+        List<Tab> tabs = tabsOfPlan.stream()
+            .filter(each -> each.getNext() == null)
+            .toList();
+        if (tabs.size() > 1) {
+            throw new ApiException(ErrorCode.SERVER_ERROR);
+        }
+        if (tabs.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(tabs.get(0));
     }
 
     public TabRetrieveResponse retrieve(Long id, Long userId) {

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -1,14 +1,70 @@
 package com.example.planservice.application;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
 import com.example.planservice.presentation.dto.response.TabRetrieveResponse;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TabService {
+    private static final int TAB_MAX_SIZE = 5;
+
+    private final PlanRepository planRepository;
+    private final MemberOfPlanRepository memberOfPlanRepository;
+    private final TabRepository tabRepository;
+
+    @Transactional
     public Long create(Long userId, TabCreateRequest request) {
-        return null;
+        Plan plan = planRepository.findById(request.getPlanId())
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        boolean existsInPlan = memberOfPlanRepository.existsByPlanIdAndMemberId(plan.getId(), userId);
+        if (!existsInPlan) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
+        }
+
+        List<Tab> tabsOfPlan = tabRepository.findAllByPlanId(plan.getId());
+        if (tabsOfPlan.size() >= TAB_MAX_SIZE) {
+            throw new ApiException(ErrorCode.TAB_SIZE_LIMIT);
+        }
+
+        boolean isDuplicatedName = tabsOfPlan.stream()
+            .anyMatch(tab -> Objects.equals(tab.getName(), request.getName()));
+        if (isDuplicatedName) {
+            throw new ApiException(ErrorCode.TAB_NAME_DUPLICATE);
+        }
+
+        Optional<Integer> maxSequenceOpt = tabsOfPlan.stream()
+            .map(Tab::getSequence)
+            .max(Integer::compareTo);
+
+        int maxSequence = 0;
+        if (maxSequenceOpt.isPresent()) {
+            maxSequence = maxSequenceOpt.get();
+        }
+
+        Tab tab = Tab.builder()
+            .name(request.getName())
+            .plan(plan)
+            .sequence(maxSequence + 1)
+            .build();
+        Tab savedTab = tabRepository.save(tab);
+        return savedTab.getId();
     }
 
     public TabRetrieveResponse retrieve(Long id, Long userId) {

--- a/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
@@ -11,9 +11,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Where(clause = "is_deleted = false")
 public class Member extends BaseEntity {
     @Id
@@ -34,4 +40,14 @@ public class Member extends BaseEntity {
 
     private boolean isDeleted;
 
+    @Builder
+    private Member(String profileImgUri, String name, String email, boolean receiveEmails, Role role,
+                   boolean isDeleted) {
+        this.profileImgUri = profileImgUri;
+        this.name = name;
+        this.email = email;
+        this.receiveEmails = receiveEmails;
+        this.role = role;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/member/repository/MemberRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.planservice.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.planservice.domain.member.Member;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/MemberOfPlan.java
@@ -12,8 +12,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Table(name = "members_of_plan")
 public class MemberOfPlan extends BaseEntity {
     @Id
@@ -28,4 +34,10 @@ public class MemberOfPlan extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    private MemberOfPlan(Plan plan, Member member) {
+        this.plan = plan;
+        this.member = member;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
@@ -1,0 +1,11 @@
+package com.example.planservice.domain.memberofplan.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+
+@Repository
+public interface MemberOfPlanRepository extends JpaRepository<MemberOfPlan, Long> {
+    boolean existsByPlanIdAndMemberId(Long planId, Long memberId);
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -13,9 +13,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "plans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Where(clause = "is_deleted = false")
 public class Plan extends BaseEntity {
     @Id
@@ -38,4 +44,16 @@ public class Plan extends BaseEntity {
     private int viewCnt;
 
     private boolean isDeleted;
+
+    @Builder
+    public Plan(Member owner, String title, String intro, boolean isPublic, int starCnt, int viewCnt,
+                boolean isDeleted) {
+        this.owner = owner;
+        this.title = title;
+        this.intro = intro;
+        this.isPublic = isPublic;
+        this.starCnt = starCnt;
+        this.viewCnt = viewCnt;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/repository/PlanRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,10 @@
+package com.example.planservice.domain.plan.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.planservice.domain.plan.Plan;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -26,5 +26,5 @@ public class Tab extends BaseEntity {
 
     private String name;
 
-    private int order;
+    private int sequence;
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,12 +33,28 @@ public class Tab extends BaseEntity {
 
     private String name;
 
-    private int sequence;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_id")
+    private Tab next;
 
     @Builder
-    private Tab(Plan plan, String name, int sequence) {
+    private Tab(Plan plan, String name, Tab next) {
         this.plan = plan;
         this.name = name;
-        this.sequence = sequence;
+        this.next = next;
+    }
+
+    public static Tab create(Plan plan, String name) {
+        return Tab.builder()
+            .plan(plan)
+            .name(name)
+            .build();
+    }
+
+    /**
+     * 오른쪽 방향으로 Tab을 연결한다
+     */
+    public void connect(Tab next) {
+        this.next = next;
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +37,9 @@ public class Tab extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_id")
     private Tab next;
+
+    @Version
+    private int version;
 
     @Builder
     private Tab(Plan plan, String name, Tab next) {

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -11,8 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tabs")
 public class Tab extends BaseEntity {
     @Id
@@ -27,4 +33,11 @@ public class Tab extends BaseEntity {
     private String name;
 
     private int sequence;
+
+    @Builder
+    private Tab(Plan plan, String name, int sequence) {
+        this.plan = plan;
+        this.name = name;
+        this.sequence = sequence;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/repository/TabRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/repository/TabRepository.java
@@ -1,0 +1,13 @@
+package com.example.planservice.domain.tab.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.planservice.domain.tab.Tab;
+
+import java.util.List;
+
+@Repository
+public interface TabRepository extends JpaRepository<Tab, Long> {
+    List<Tab> findAllByPlanId(Long planId);
+}

--- a/plan-service/src/main/java/com/example/planservice/exception/ApiException.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ApiException.java
@@ -1,0 +1,13 @@
+package com.example.planservice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode error) {
+        super(error.getMessage());
+        this.errorCode = error;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.planservice.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    TAB_SIZE_LIMIT(HttpStatus.BAD_REQUEST, "하나의 Plan에 Tab은 5개까지만 달 수 있습니다");
+
+    private final HttpStatus status;
+    private String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND_IN_PLAN(HttpStatus.NOT_FOUND, "해당 플랜에 소속되지 않은 멤버입니다"),
     TAB_SIZE_LIMIT(HttpStatus.BAD_REQUEST, "하나의 플랜에 탭은 5개까지만 달 수 있습니다"),
     TAB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "탭 이름이 중복되었습니다"),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 관리자에게 문의하세요");
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 관리자에게 문의하세요"),
+    REQUEST_CONFLICT(HttpStatus.CONFLICT, "요청들간 충돌이 발생했습니다. 다시 시도해 주세요");
 
     private final HttpStatus status;
     private String message;

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -6,7 +6,10 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-    TAB_SIZE_LIMIT(HttpStatus.BAD_REQUEST, "하나의 Plan에 Tab은 5개까지만 달 수 있습니다");
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜이 존재하지 않습니다"),
+    MEMBER_NOT_FOUND_IN_PLAN(HttpStatus.NOT_FOUND, "해당 플랜에 소속되지 않은 멤버입니다"),
+    TAB_SIZE_LIMIT(HttpStatus.BAD_REQUEST, "하나의 플랜에 탭은 5개까지만 달 수 있습니다"),
+    TAB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "탭 이름이 중복되었습니다");
 
     private final HttpStatus status;
     private String message;

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -9,7 +9,8 @@ public enum ErrorCode {
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜이 존재하지 않습니다"),
     MEMBER_NOT_FOUND_IN_PLAN(HttpStatus.NOT_FOUND, "해당 플랜에 소속되지 않은 멤버입니다"),
     TAB_SIZE_LIMIT(HttpStatus.BAD_REQUEST, "하나의 플랜에 탭은 5개까지만 달 수 있습니다"),
-    TAB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "탭 이름이 중복되었습니다");
+    TAB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "탭 이름이 중복되었습니다"),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 관리자에게 문의하세요");
 
     private final HttpStatus status;
     private String message;

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.example.planservice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ErrorResponse {
+    private final String message;
+}

--- a/plan-service/src/main/java/com/example/planservice/exception/GlobalExceptionHandler.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.planservice.exception;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
+        return ResponseEntity.status(exception.getErrorCode().getStatus())
+            .body(new ErrorResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindingResultException(BindException exception) {
+        List<ObjectError> allErrors = exception.getBindingResult().getAllErrors();
+        return ResponseEntity.badRequest()
+            .body(new ErrorResponse(allErrors.get(0).getDefaultMessage()));
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -2,6 +2,7 @@ package com.example.planservice.presentation;
 
 import java.net.URI;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +26,10 @@ public class TabController {
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody TabCreateRequest request,
-                                       @RequestHeader("X-User-Id") Long userId) {
+                                       @RequestHeader(value = "X-User-Id", required = false) Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         Long createdId = tabService.create(userId, request);
         return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -1,0 +1,29 @@
+package com.example.planservice.presentation;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.planservice.application.TabService;
+import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tabs")
+public class TabController {
+    private final TabService tabService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody TabCreateRequest request,
+                                       @RequestHeader("X-User-Id") Long userId) {
+        Long createdId = tabService.create(userId, request);
+        return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();
+    }
+
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -3,6 +3,8 @@ package com.example.planservice.presentation;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.TabService;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import com.example.planservice.presentation.dto.response.TabRetrieveResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -27,4 +30,9 @@ public class TabController {
         return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<TabRetrieveResponse> retrieve(@PathVariable(name = "id") Long tabId,
+                                                        @RequestHeader("X-User-Id") Long userId) {
+        return ResponseEntity.ok().body(tabService.retrieve(tabId, userId));
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -36,7 +36,11 @@ public class TabController {
 
     @GetMapping("/{id}")
     public ResponseEntity<TabRetrieveResponse> retrieve(@PathVariable(name = "id") Long tabId,
-                                                        @RequestHeader("X-User-Id") Long userId) {
+                                                        @RequestHeader(
+                                                            value = "X-User-Id", required = false) Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         return ResponseEntity.ok().body(tabService.retrieve(tabId, userId));
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.TabService;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -20,7 +21,7 @@ public class TabController {
     private final TabService tabService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody TabCreateRequest request,
+    public ResponseEntity<Void> create(@Valid @RequestBody TabCreateRequest request,
                                        @RequestHeader("X-User-Id") Long userId) {
         Long createdId = tabService.create(userId, request);
         return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
@@ -1,0 +1,16 @@
+package com.example.planservice.presentation.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TabCreateRequest {
+    private String name;
+
+    @Builder
+    private TabCreateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.planservice.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class TabCreateRequest {
+    @NotBlank
     private String name;
 
     @Builder

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TabCreateRequest.java
@@ -1,6 +1,7 @@
 package com.example.planservice.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +12,12 @@ public class TabCreateRequest {
     @NotBlank
     private String name;
 
+    @NotNull
+    private Long planId;
+
     @Builder
-    private TabCreateRequest(String name) {
+    private TabCreateRequest(String name, Long planId) {
         this.name = name;
+        this.planId = planId;
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabRetrieveResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabRetrieveResponse.java
@@ -1,4 +1,20 @@
 package com.example.planservice.presentation.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
 public class TabRetrieveResponse {
+    private Long tabId;
+    private Long planId;
+    private String name;
+
+    @Builder
+    private TabRetrieveResponse(Long tabId, Long planId, String name) {
+        this.tabId = tabId;
+        this.planId = planId;
+        this.name = name;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabRetrieveResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabRetrieveResponse.java
@@ -1,0 +1,4 @@
+package com.example.planservice.presentation.dto.response;
+
+public class TabRetrieveResponse {
+}

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -153,7 +153,7 @@ class TabServiceTest {
         Plan plan = createPlan();
         Member member = createMember();
         createMemberOfPlan(plan, member);
-        createTab(plan, tabName, 0);
+        createTab(plan, tabName, null);
 
         TabCreateRequest request = createTabCreateRequest(plan.getId(), tabName);
 
@@ -171,8 +171,8 @@ class TabServiceTest {
         Member member = createMember();
         createMemberOfPlan(plan, member);
 
-        Tab tab1 = createTab(plan, "이전탭1", 1);
-        Tab tab2 = createTab(plan, "이전탭2", 2);
+        Tab tab2 = createTab(plan, "이전탭2", null);
+        Tab tab1 = createTab(plan, "이전탭1", tab2);
         tabRepository.saveAll(List.of(tab1, tab2));
 
         TabCreateRequest request = createTabCreateRequest(plan.getId(), "탭이름");
@@ -184,15 +184,15 @@ class TabServiceTest {
         assertThat(savedId).isNotNull();
 
         Tab savedTab = tabRepository.findById(savedId).get();
-        assertThat(savedTab.getSequence()).isGreaterThan(tab1.getSequence());
-        assertThat(savedTab.getSequence()).isGreaterThan(tab2.getSequence());
+        assertThat(tab2.getNext()).isEqualTo(savedTab);
+        assertThat(savedTab.getNext()).isNull();
     }
 
-    private Tab createTab(Plan plan, String name, Integer sequence) {
+    private Tab createTab(Plan plan, String name, Tab next) {
         Tab tab = Tab.builder()
             .plan(plan)
-            .sequence(sequence)
             .name(name)
+            .next(next)
             .build();
         tabRepository.save(tab);
         return tab;

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -1,0 +1,233 @@
+package com.example.planservice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.TabCreateRequest;
+
+@SpringBootTest
+@Transactional
+class TabServiceTest {
+    @Autowired
+    TabService tabService;
+
+    @Autowired
+    TabRepository tabRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Autowired
+    MemberOfPlanRepository memberOfPlanRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("탭을 생성한다")
+    void create() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), "새로운탭");
+
+        // when
+        Long savedId = tabService.create(member.getId(), request);
+
+        // then
+        assertThat(savedId).isNotNull();
+
+        Tab savedTab = tabRepository.findById(savedId).get();
+        assertThat(savedTab.getName()).isEqualTo(request.getName());
+        assertThat(savedTab.getPlan().getId()).isEqualTo(request.getPlanId());
+    }
+
+
+    @Test
+    @DisplayName("탭은 존재하는 플랜에 대해서만 생성할 수 있다")
+    void createFailNotExistPlan() {
+        // given
+        Long userId = 1L;
+        Long notRegisteredPlanId = 10L;
+        TabCreateRequest request = createTabCreateRequest(notRegisteredPlanId, "탭이름");
+
+        // when & then
+        assertThatThrownBy(() -> tabService.create(userId, request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("탭을 생성하는 사람은 해당 플랜에 소속되어 있어야 한다")
+    void createFailNotMemberOfPlan() {
+        // given
+        Plan plan = createPlan();
+
+        Long userId = 1L;
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), "이름");
+
+        // when & then
+        assertThatThrownBy(() -> tabService.create(userId, request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
+    }
+
+    @Test
+    @DisplayName("하나의 플랜에 탭은 최대 5개까지 생성 가능하다")
+    @SuppressWarnings("squid:S5778")
+    void createFailTabLimitOver() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+
+        Tab tab1 = Tab.builder().plan(plan).build();
+        Tab tab2 = Tab.builder().plan(plan).build();
+        Tab tab3 = Tab.builder().plan(plan).build();
+        Tab tab4 = Tab.builder().plan(plan).build();
+        Tab tab5 = Tab.builder().plan(plan).build();
+        tabRepository.saveAll(List.of(tab1, tab2, tab3, tab4, tab5));
+
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), "이름");
+
+        // when & then
+        assertThatThrownBy(() -> tabService.create(member.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TAB_SIZE_LIMIT.getMessage());
+    }
+
+    @Test
+    @DisplayName("탭이 4개인 경우 생성에 성공한다")
+    void createSuccessTabSizeNotOver() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+
+        Tab tab1 = Tab.builder().plan(plan).build();
+        Tab tab2 = Tab.builder().plan(plan).build();
+        Tab tab3 = Tab.builder().plan(plan).build();
+        Tab tab4 = Tab.builder().plan(plan).build();
+        tabRepository.saveAll(List.of(tab1, tab2, tab3, tab4));
+
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), "이름");
+
+        // when
+        Long savedId = tabService.create(member.getId(), request);
+
+        // then
+        assertThat(savedId).isNotNull();
+
+        Tab savedTab = tabRepository.findById(savedId).get();
+        assertThat(savedTab.getName()).isEqualTo(request.getName());
+        assertThat(savedTab.getPlan().getId()).isEqualTo(request.getPlanId());
+    }
+
+    @Test
+    @DisplayName("동일한 플랜에서 탭 이름은 중복될 수 없다")
+    @SuppressWarnings("squid:S5778")
+    void createFailDuplicatedTabName() {
+        // given
+        String tabName = "탭이름";
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+        createTab(plan, tabName, 0);
+
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), tabName);
+
+        // when & then
+        assertThatThrownBy(() -> tabService.create(member.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TAB_NAME_DUPLICATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("새롭게 생성된 탭은 가장 마지막 순서를 갖는다")
+    void isLastSequenceAboutCreatedTab() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+
+        Tab tab1 = createTab(plan, "이전탭1", 1);
+        Tab tab2 = createTab(plan, "이전탭2", 2);
+        tabRepository.saveAll(List.of(tab1, tab2));
+
+        TabCreateRequest request = createTabCreateRequest(plan.getId(), "탭이름");
+
+        // when
+        Long savedId = tabService.create(member.getId(), request);
+
+        // then
+        assertThat(savedId).isNotNull();
+
+        Tab savedTab = tabRepository.findById(savedId).get();
+        assertThat(savedTab.getSequence()).isGreaterThan(tab1.getSequence());
+        assertThat(savedTab.getSequence()).isGreaterThan(tab2.getSequence());
+    }
+
+    private Tab createTab(Plan plan, String name, Integer sequence) {
+        Tab tab = Tab.builder()
+            .plan(plan)
+            .sequence(sequence)
+            .name(name)
+            .build();
+        tabRepository.save(tab);
+        return tab;
+    }
+
+    @NotNull
+    private MemberOfPlan createMemberOfPlan(Plan plan, Member member) {
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member)
+            .build();
+        memberOfPlanRepository.save(memberOfPlan);
+        return memberOfPlan;
+    }
+
+    @NotNull
+    private Member createMember() {
+        Member member = Member.builder()
+            .build();
+        memberRepository.save(member);
+        return member;
+    }
+
+    @NotNull
+    private Plan createPlan() {
+        Plan plan = Plan.builder().build();
+        planRepository.save(plan);
+        return plan;
+    }
+
+    @NotNull
+    private TabCreateRequest createTabCreateRequest(Long planId, String name) {
+        return TabCreateRequest.builder()
+            .name(name)
+            .planId(planId)
+            .build();
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.example.planservice.domain.memberofplan.repository;
+
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MemberOfPlanRepositoryTest {
+    @Autowired
+    MemberOfPlanRepository memberOfPlanRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Test
+    @DisplayName("플랜에 유저가 존재하면 true를 반환한다")
+    void existsByPlanIdAndMemberIdTrue() {
+        // given
+        Member member = Member.builder().build();
+        memberRepository.save(member);
+        Plan plan = Plan.builder().build();
+        planRepository.save(plan);
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .member(member)
+            .plan(plan)
+            .build();
+        memberOfPlanRepository.save(memberOfPlan);
+
+        // when
+        boolean exists = memberOfPlanRepository.existsByPlanIdAndMemberId(plan.getId(), member.getId());
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("플랜에 유저가 없으면 false를 반환한다")
+    void existsByPlanIdAndMemberIdFail() {
+        // given
+        Long planId = 1L;
+        Long memberId = 10L;
+
+        // when
+        boolean exists = memberOfPlanRepository.existsByPlanIdAndMemberId(planId, memberId);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+}

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabTest.java
@@ -1,0 +1,40 @@
+package com.example.planservice.domain.tab;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.planservice.domain.plan.Plan;
+
+class TabTest {
+    @Test
+    @DisplayName("탭을 생성한다")
+    void createTab() {
+        // given
+        Plan plan = Plan.builder().build();
+
+        // when
+        Tab tab = Tab.create(plan, "탭이름");
+
+        // then
+        assertThat(tab.getName()).isEqualTo("탭이름");
+        assertThat(tab.getNext()).isNull();
+        assertThat(tab.getPlan()).isEqualTo(plan);
+    }
+
+    @Test
+    @DisplayName("탭은 오른쪽 방향으로 연결된다")
+    void connectTab() {
+        // given
+        Plan plan = Plan.builder().build();
+        Tab oldTab = Tab.create(plan, "탭이름");
+        Tab newTab = Tab.create(plan, "새로운탭");
+
+        // when
+        oldTab.connect(newTab);
+
+        assertThat(oldTab.getNext()).isEqualTo(newTab);
+    }
+
+}

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/repository/TabRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/repository/TabRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.example.planservice.domain.tab.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.domain.tab.Tab;
+
+@SpringBootTest
+class TabRepositoryTest {
+    @Autowired
+    TabRepository tabRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Test
+    @DisplayName("플랜 아이디로 모든 Tab을 조회한다")
+    void findAllByPlanId() {
+        // given
+        Plan plan = Plan.builder().build();
+        planRepository.save(plan);
+
+        Tab tab1 = Tab.builder()
+            .name("탭1")
+            .plan(plan)
+            .build();
+        Tab tab2 = Tab.builder()
+            .name("탭2")
+            .plan(plan)
+            .build();
+        Tab tab3 = Tab.builder()
+            .name("탭3")
+            .build();
+        tabRepository.saveAll(List.of(tab1, tab2, tab3));
+
+        // when
+        List<Tab> tabs = tabRepository.findAllByPlanId(plan.getId());
+
+        // then
+        assertThat(tabs).hasSize(2)
+            .extracting("name")
+            .contains("탭1", "탭2");
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,7 +21,6 @@ import com.example.planservice.application.TabService;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest
@@ -65,6 +66,40 @@ class TabControllerTest {
 
         Mockito.when(tabService.create(anyLong(), any(TabCreateRequest.class)))
             .thenThrow(new ApiException(ErrorCode.TAB_SIZE_LIMIT));
+
+        // when & then
+        mockMvc.perform(post("/tabs")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("탭의 이름은 공백이 될 수 없다")
+    @ValueSource(strings = {"", " ", "  "})
+    void createTabFailTabNameBlank(String name) throws Exception {
+        // given
+        Long userId = 1L;
+        TabCreateRequest request = TabCreateRequest.builder()
+            .name(name)
+            .build();
+
+        // when & then
+        mockMvc.perform(post("/tabs")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("탭의 이름은 null이 될 수 없다")
+    void createTabFailTabNameNull() throws Exception {
+        // given
+        Long userId = 1L;
+        TabCreateRequest request = TabCreateRequest.builder()
+            .build();
 
         // when & then
         mockMvc.perform(post("/tabs")

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -3,6 +3,8 @@ package com.example.planservice.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -10,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,6 +22,7 @@ import com.example.planservice.application.TabService;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import com.example.planservice.presentation.dto.response.TabRetrieveResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest
@@ -64,7 +66,7 @@ class TabControllerTest {
             .name("탭이름")
             .build();
 
-        Mockito.when(tabService.create(anyLong(), any(TabCreateRequest.class)))
+        when(tabService.create(anyLong(), any(TabCreateRequest.class)))
             .thenThrow(new ApiException(ErrorCode.TAB_SIZE_LIMIT));
 
         // when & then
@@ -109,4 +111,23 @@ class TabControllerTest {
             .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("탭을 조회한다")
+    void retrieveTab() throws Exception {
+        // given
+        Long userId = 1L;
+        Long tabId = 10L;
+        TabRetrieveResponse response = TabRetrieveResponse.builder()
+            .tabId(tabId)
+            .build();
+
+        when(tabService.retrieve(tabId, userId))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/tabs/" + tabId)
+                .header("X-User-Id", userId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.tabId").value(tabId));
+    }
+    
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -144,4 +144,16 @@ class TabControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.tabId").value(tabId));
     }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 Tab을 가져올 수 없다")
+    void retrieveTabFailNotLogin() throws Exception {
+        // given
+        Long tabId = 10L;
+
+        // when & then
+        mockMvc.perform(get("/tabs/" + tabId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+    }
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -55,10 +55,25 @@ class TabControllerTest {
             .andExpect(redirectedUrlPattern("/tabs/*"));
     }
 
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 Tab을 생성할 수 없다")
+    void createtabFailNotLogin() throws Exception {
+        // given
+        TabCreateRequest request = TabCreateRequest.builder()
+            .name("탭이름")
+            .build();
+
+        // when & then
+        mockMvc.perform(post("/tabs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+
     // TODO 해당 테스트가 필요할까요? TAB_SIZE_LIMIT Api Exception이 터지면 400번 응답이 나오는지 테스트하는 로직인데
     //  ErrorCode와 관련해서 테스트가 들어가는게 맞다는 생각이 듭니다.
     @Test
-    @DisplayName("하나의 프로젝트에 Tab은 최대 5개까지만 생성이 가능하다")
+    @DisplayName("하나의 플랜에 Tab은 최대 5개까지만 생성이 가능하다")
     void createTabFailSizeOver() throws Exception {
         // given
         Long userId = 1L;
@@ -129,5 +144,4 @@ class TabControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.tabId").value(tabId));
     }
-    
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.planservice.presentation;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.planservice.application.TabService;
+import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest
+class TabControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    TabService tabService;
+
+    @Test
+    @DisplayName("Tab을 생성한다")
+    void createTab() throws Exception {
+        // given
+        Long userId = 1L;
+        TabCreateRequest request = TabCreateRequest.builder()
+            .name("탭이름")
+            .build();
+
+        // when & then
+        mockMvc.perform(post("/tabs")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(header().exists("Location"))
+            .andExpect(redirectedUrlPattern("/tabs/*"));
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -41,8 +41,10 @@ class TabControllerTest {
     void createTab() throws Exception {
         // given
         Long userId = 1L;
+        Long planId = 10L;
         TabCreateRequest request = TabCreateRequest.builder()
             .name("탭이름")
+            .planId(planId)
             .build();
 
         // when & then
@@ -59,8 +61,10 @@ class TabControllerTest {
     @DisplayName("로그인하지 않은 사용자는 Tab을 생성할 수 없다")
     void createtabFailNotLogin() throws Exception {
         // given
+        Long planId = 10L;
         TabCreateRequest request = TabCreateRequest.builder()
             .name("탭이름")
+            .planId(planId)
             .build();
 
         // when & then
@@ -77,8 +81,10 @@ class TabControllerTest {
     void createTabFailSizeOver() throws Exception {
         // given
         Long userId = 1L;
+        Long planId = 10L;
         TabCreateRequest request = TabCreateRequest.builder()
             .name("탭이름")
+            .planId(planId)
             .build();
 
         when(tabService.create(anyLong(), any(TabCreateRequest.class)))
@@ -98,8 +104,10 @@ class TabControllerTest {
     void createTabFailTabNameBlank(String name) throws Exception {
         // given
         Long userId = 1L;
+        Long planId = 10L;
         TabCreateRequest request = TabCreateRequest.builder()
             .name(name)
+            .planId(planId)
             .build();
 
         // when & then
@@ -115,7 +123,26 @@ class TabControllerTest {
     void createTabFailTabNameNull() throws Exception {
         // given
         Long userId = 1L;
+        Long planId = 10L;
         TabCreateRequest request = TabCreateRequest.builder()
+            .planId(planId)
+            .build();
+
+        // when & then
+        mockMvc.perform(post("/tabs")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("탭을 등록할 때 Project Id는 필수다")
+    void createTabFailEmptyProjectId() throws Exception {
+        // given
+        Long userId = 1L;
+        TabCreateRequest request = TabCreateRequest.builder()
+            .name("탭이름")
             .build();
 
         // when & then


### PR DESCRIPTION
📌 Description
탭을 생성하는 로직은 아래 순서로 진행됩니다.
1. 플랜을 가져온다.
2. 작성자가 플랜에 소속되어 있는지 확인한다.
3. 해당 플랜에 속한 모든 탭을 가져온다.
  3-1. 만약 해당 플랜에 이미 N개 이상 존재한다면 예외를 반환한다.
4. 새로운 탭을 생성해 저장한다.
5. 3에서 가져온 탭 중 next 컬럼이 null인 값을 찾는다. 해당 탭의 next에 4에서 만든 탭을 저장한다.

원래 탭 엔티티에는 int 타입의 sequence 필드가 있었습니다. 하지만 링크드 리스트 방식이 순서를 관리하기에 효율적이라고 생각이 들어 @OneToOne 방식으로 관계를 맺어줬습니다.

탭 엔티티에 대해 낙관적 락을 걸었습니다. 탭을 생성하는 로직이 동시에 실행되는 경우를 막기 위함입니다.
Plan에 속한 여러 탭 중 next가 null인 탭은 하나만 존재해야 합니다.
MySQL은 고립 수준이 Repeatable Read 라서 여러 트랜잭션이 동시에 실행되며 next가 null인 탭이 여러개가 될 수 있습니다.
Tab 엔티티에 version이라는 필드를 추가해 낙관적 락을 걸어주었습니다.

주말을 활용해서 트랜잭션 격리 수준에 대해 학습하고 블로그에 글을 작성하겠습니다.

⚠️ 주의사항
없습니다.

close #24 