### PR TITLE
[#56] plan-service 인증을 처리하는 인터셉터 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
+++ b/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.example.planservice.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.example.planservice.interceptor.AuthenticationInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private static final List<String> whiteList = List.of();
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor())
+            .excludePathPatterns(whiteList);
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
+++ b/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,27 @@
+package com.example.planservice.interceptor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String userIdStr = request.getHeader("X-User-Id");
+        if (userIdStr == null || userIdStr.isEmpty()) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        try {
+            Long userId = Long.parseLong(userIdStr);
+            request.setAttribute("userId", userId);
+            return true;
+        } catch (NumberFormatException e) {
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            return false;
+        }
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -3,14 +3,13 @@ package com.example.planservice.presentation;
 import java.net.URI;
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,21 +31,14 @@ public class TabController {
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody TabCreateRequest request,
-                                       @RequestHeader(value = "X-User-Id", required = false) Long userId) {
-        if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+                                       @RequestAttribute Long userId) {
         Long createdId = tabService.create(userId, request);
         return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();
     }
 
     @PostMapping("/change-order")
     public ResponseEntity<ChangeOrderResponse> changeOrder(@Valid @RequestBody TabChangeOrderRequest request,
-                                                           @RequestHeader(value = "X-User-Id",
-                                                               required = false) Long userId) {
-        if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+                                                           @RequestAttribute Long userId) {
         List<Long> sortedTabList = tabService.changeOrder(userId, request);
         return ResponseEntity.ok().body(new ChangeOrderResponse(sortedTabList));
     }
@@ -54,21 +46,13 @@ public class TabController {
     @PatchMapping("/{tabId}/name")
     public ResponseEntity<TabChangeNameResponse> changeName(@PathVariable Long tabId,
                                                             @Valid @RequestBody TabChangeNameRequest request,
-                                                            @RequestHeader(value = "X-User-Id",
-                                                                required = false) Long userId) {
-        if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+                                                            @RequestAttribute Long userId) {
         return ResponseEntity.ok().body(tabService.changeName(request.toServiceRequest(userId, tabId)));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<TabRetrieveResponse> retrieve(@PathVariable(name = "id") Long tabId,
-                                                        @RequestHeader(
-                                                            value = "X-User-Id", required = false) Long userId) {
-        if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+                                                        @RequestAttribute Long userId) {
         return ResponseEntity.ok().body(tabService.retrieve(tabId, userId));
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
+++ b/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AuthenticationInterceptorTest {
     AuthenticationInterceptor interceptor;
     MockHttpServletRequest request;

--- a/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
+++ b/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
@@ -1,0 +1,64 @@
+package com.example.planservice.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@SpringBootTest
+class AuthenticationInterceptorTest {
+    AuthenticationInterceptor interceptor;
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
+
+    @BeforeEach
+    void setup() {
+        interceptor = new AuthenticationInterceptor();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "10", "11111111", "9223372036854775807"})
+    @DisplayName("X-User-Id가 Long 타입이면 AuthenticationInterceptor의 preHandle 메서드는 true를 반환한다")
+    void authenticationInterceptorSuccess(String value) {
+        // given
+        request.addHeader("X-User-Id", value);
+
+        // when
+        boolean result = interceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("X-User-Id가 없으면 AuthenticationInterceptor의 preHandle 메서드는 false를 반환한다")
+    void authenticationInterceptorFailUserIdNotFound() {
+        // when
+        boolean result = interceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "d", "a", "9223372036854775808"})
+    @DisplayName("X-User-Id가 숫자가 아니면 AuthenticationInterceptor의 preHandle 메서드는 false를 반환한다")
+    void authenticationInterceptorFailUserIdNotFound(String value) {
+        // given
+        request.addHeader("X-User-Id", value);
+
+        // when
+        boolean result = interceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
📌 Description
변경사항 : 인증을 처리하는 위치를 Controller에서 AuthenticationInterceptor로 변경


문제 상황 : 기존에 Controller 각 메서드마다 인증을 처리하는 로직이 반복적으로 들어갔습니다.

해결 : 인터셉터를 사용해 공통적으로 처리되도록 만들었습니다.

인터셉터 테스트는 단위테스트만을 만들었습니다.
Controller를 테스트할 때 @WebMvcTest로 인해 인터셉터가 함께 동작합니다.
해당 테스트에서 Header 유무에 따라 401 상태값을 뱉는걸 검사하고 있기 때문에, 인터셉터 통합 테스트는 필요없다고 생각했습니다.

⚠️ 주의사항
없습니다.

close https://github.com/Side-Project-Planting/Backend/issues/56