### PR TITLE
[#26] 태스크 생성 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/PlanMembershipVerificationService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanMembershipVerificationService.java
@@ -1,0 +1,28 @@
+package com.example.planservice.application;
+
+import org.springframework.stereotype.Service;
+
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlanMembershipVerificationService {
+    private final PlanRepository planRepository;
+    private final MemberOfPlanRepository memberOfPlanRepository;
+
+    public Plan verifyAndReturnPlan(Long planId, Long memberId) {
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        boolean existsInPlan = memberOfPlanRepository.existsByPlanIdAndMemberId(plan.getId(), memberId);
+        if (!existsInPlan) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
+        }
+        return plan;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -1,9 +1,6 @@
 package com.example.planservice.application;
 
-import static com.example.planservice.domain.tab.Tab.TAB_MAX_SIZE;
-
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.jetbrains.annotations.NotNull;
@@ -36,25 +33,11 @@ public class TabService {
     public Long create(Long memberId, TabCreateRequest request) {
         try {
             Plan plan = planMembershipVerificationService.verifyAndReturnPlan(request.getPlanId(), memberId);
-            // TODO 여기도 탭그룹으로 관리할 수 있겠는데??
             List<Tab> tabsOfPlan = tabRepository.findAllByPlanId(plan.getId());
-            if (tabsOfPlan.size() >= TAB_MAX_SIZE) {
-                throw new ApiException(ErrorCode.TAB_SIZE_INVALID);
-            }
-
-            boolean isDuplicatedName = tabsOfPlan.stream()
-                .anyMatch(tab -> Objects.equals(tab.getName(), request.getName()));
-            if (isDuplicatedName) {
-                throw new ApiException(ErrorCode.TAB_NAME_DUPLICATE);
-            }
 
             Tab createdTab = Tab.create(plan, request.getName());
-
-            Optional<Tab> lastOpt = findLastTab(tabsOfPlan);
-            if (lastOpt.isPresent()) {
-                Tab last = lastOpt.get();
-                last.connect(createdTab);
-            }
+            TabGroup tabGroup = new TabGroup(plan, tabsOfPlan);
+            tabGroup.addLast(createdTab);
 
             Tab savedTab = tabRepository.save(createdTab);
             return savedTab.getId();

--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -1,14 +1,21 @@
 package com.example.planservice.application;
 
+import java.util.List;
+import java.util.Objects;
+
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.label.repository.LabelRepository;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.LabelOfTask;
 import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.LabelOfTaskRepository;
 import com.example.planservice.domain.task.repository.TaskRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
@@ -23,11 +30,13 @@ public class TaskService {
     private final TabRepository tabRepository;
     private final MemberRepository memberRepository;
     private final PlanMembershipVerificationService planMembershipVerificationService;
+    private final LabelRepository labelRepository;
+    private final LabelOfTaskRepository labelOfTaskRepository;
 
     @Transactional
     public Long createTask(Long memberId, TaskCreateRequest request) {
         try {
-            planMembershipVerificationService.verifyAndReturnPlan(request.getPlanId(), memberId);
+            Plan plan = planMembershipVerificationService.verifyAndReturnPlan(request.getPlanId(), memberId);
             Tab tab = tabRepository.findById(request.getTabId())
                 .orElseThrow(() -> new ApiException(ErrorCode.TAB_NOT_FOUND_IN_PLAN));
             Member manager = memberRepository.findById(request.getManagerId())
@@ -46,10 +55,20 @@ public class TaskService {
             }
 
             Task savedTask = taskRepository.save(task);
+
+            saveAllLabelOfTask(request.getLabels(), task, plan);
             return savedTask.getId();
         } catch (ObjectOptimisticLockingFailureException e) {
             throw new ApiException(ErrorCode.REQUEST_CONFLICT);
         }
+    }
+
+    private void saveAllLabelOfTask(List<Long> labelIds, Task task, Plan plan) {
+        List<LabelOfTask> labelsOfTask = labelRepository.findAllById(labelIds).stream()
+            .filter(label -> Objects.equals(label.getPlan(), plan))
+            .map(label -> LabelOfTask.create(label, task))
+            .toList();
+        labelOfTaskRepository.saveAll(labelsOfTask);
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -1,0 +1,55 @@
+package com.example.planservice.application;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.TaskRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TaskService {
+    private final TaskRepository taskRepository;
+    private final TabRepository tabRepository;
+    private final MemberRepository memberRepository;
+    private final PlanMembershipVerificationService planMembershipVerificationService;
+
+    @Transactional
+    public Long createTask(Long memberId, TaskCreateRequest request) {
+        try {
+            planMembershipVerificationService.verifyAndReturnPlan(request.getPlanId(), memberId);
+            Tab tab = tabRepository.findById(request.getTabId())
+                .orElseThrow(() -> new ApiException(ErrorCode.TAB_NOT_FOUND_IN_PLAN));
+            Member manager = memberRepository.findById(request.getManagerId())
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN));
+
+            Task task = Task.builder()
+                .tab(tab)
+                .manager(manager)
+                .name(request.getName())
+                .description(request.getDescription())
+                .build();
+
+            Task oldLastTask = tab.makeLastTask(task);
+            if (oldLastTask != null) {
+                oldLastTask.connect(task);
+            }
+
+            Task savedTask = taskRepository.save(task);
+            return savedTask.getId();
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new ApiException(ErrorCode.REQUEST_CONFLICT);
+        }
+    }
+
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -11,9 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "labels")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Label extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +31,10 @@ public class Label extends BaseEntity {
     private Plan plan;
 
     private String name;
+
+    @Builder
+    private Label(Plan plan, String name) {
+        this.plan = plan;
+        this.name = name;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/label/repository/LabelRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/repository/LabelRepository.java
@@ -1,0 +1,8 @@
+package com.example.planservice.domain.label.repository;
+
+import com.example.planservice.domain.label.Label;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LabelRepository extends JpaRepository<Label, Long> {
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.task.Task;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -47,15 +48,19 @@ public class Tab extends BaseEntity {
 
     private boolean first;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Task lastTask;
+
     @Version
     private int version;
 
     @Builder
-    private Tab(Plan plan, String name, Tab next, boolean first) {
+    private Tab(Plan plan, String name, Tab next, boolean first, Task lastTask) {
         this.plan = plan;
         this.name = name;
         this.next = next;
         this.first = first;
+        this.lastTask = lastTask;
     }
 
     public static Tab create(Plan plan, String name) {
@@ -88,5 +93,11 @@ public class Tab extends BaseEntity {
     public void changeName(@NotNull String name) {
         // TODO Tab 이름에 대한 제약조건 이야기해보기
         this.name = name;
+    }
+
+    public Task makeLastTask(Task task) {
+        Task temp = this.lastTask;
+        this.lastTask = task;
+        return temp;
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
@@ -60,20 +60,13 @@ public class TabGroup {
             throw new ApiException(ErrorCode.TAB_ORDER_FIXED);
         }
 
-        Tab newPrev = findById(newPrevId);
         Tab oldPrev = findPrev(target);
-
         oldPrev.connect(target.getNext());
-        target.connect(newPrev.getNext());
-        newPrev.connect(target);
 
-        List<Tab> result = new ArrayList<>();
-        Tab temp = first;
-        while (temp != null) {
-            result.add(temp);
-            temp = temp.getNext();
-        }
-        return result;
+        Tab newPrev = findById(newPrevId);
+        add(newPrev, target);
+
+        return getSortedTabs();
     }
 
     public Tab findById(long id) {

--- a/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/LabelOfTask.java
@@ -11,9 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "labels_of_task")
+@Getter
 public class LabelOfTask extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +33,17 @@ public class LabelOfTask extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "label_id")
     private Label label;
+
+    @Builder
+    private LabelOfTask(Task task, Label label) {
+        this.task = task;
+        this.label = label;
+    }
+
+    public static LabelOfTask create(Label label, Task task) {
+        return LabelOfTask.builder()
+            .label(label)
+            .task(task)
+            .build();
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -16,10 +16,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "tasks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "is_deleted = false")
+@Getter
 public class Task extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,4 +55,44 @@ public class Task extends BaseEntity {
     private LocalDateTime endDate;
 
     private boolean isDeleted;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_id")
+    private Task next;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "prev_id")
+    private Task prev;
+
+    @Version
+    private int version;
+
+    @Builder
+    @SuppressWarnings("java:S107")
+    public Task(Tab tab, Member manager, Member writer, String name, String description, LocalDateTime startDate,
+                LocalDateTime endDate, boolean isDeleted, Task next, Task prev, int version) {
+        this.tab = tab;
+        this.manager = manager;
+        this.writer = writer;
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isDeleted = isDeleted;
+        this.next = next;
+        this.prev = prev;
+        this.version = version;
+    }
+
+    public void connect(Task next) {
+        if (next == null) {
+            this.next = null;
+            return;
+        }
+
+        this.next = next;
+        next.prev = this;
+    }
+
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/task/repository/LabelOfTaskRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/repository/LabelOfTaskRepository.java
@@ -1,0 +1,10 @@
+package com.example.planservice.domain.task.repository;
+
+import com.example.planservice.domain.task.LabelOfTask;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LabelOfTaskRepository extends JpaRepository<LabelOfTask, Long> {
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/task/repository/TaskRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/repository/TaskRepository.java
@@ -1,0 +1,13 @@
+package com.example.planservice.domain.task.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.planservice.domain.task.Task;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findAllByTabId(Long tabId);
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
@@ -1,0 +1,30 @@
+package com.example.planservice.presentation;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.planservice.application.TaskService;
+import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+    private final TaskService taskService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody @Valid TaskCreateRequest request,
+                                       @RequestAttribute Long userId) {
+        Long createdId = taskService.createTask(userId, request);
+        return ResponseEntity.created(URI.create("/tasks/" + createdId)).build();
+    }
+
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
@@ -1,6 +1,7 @@
 package com.example.planservice.presentation.dto.request;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.example.planservice.domain.task.Task;
 import lombok.Builder;
@@ -17,10 +18,12 @@ public class TaskCreateRequest {
     private String description;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+    private List<Long> labels;
 
     @Builder
+    @SuppressWarnings("java:S107")
     private TaskCreateRequest(Long planId, Long tabId, Long managerId, String name, String description,
-                              LocalDateTime startDate, LocalDateTime endDate) {
+                              LocalDateTime startDate, LocalDateTime endDate, List<Long> labels) {
         this.planId = planId;
         this.tabId = tabId;
         this.managerId = managerId;
@@ -28,6 +31,7 @@ public class TaskCreateRequest {
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.labels = labels;
     }
 
     public Task toEntity() {

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
@@ -1,0 +1,36 @@
+package com.example.planservice.presentation.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.example.planservice.domain.task.Task;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TaskCreateRequest {
+    private Long planId;
+    private Long tabId;
+    private Long managerId;
+    private String name;
+    private String description;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    @Builder
+    private TaskCreateRequest(Long planId, Long tabId, Long managerId, String name, String description,
+                              LocalDateTime startDate, LocalDateTime endDate) {
+        this.planId = planId;
+        this.tabId = tabId;
+        this.managerId = managerId;
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public Task toEntity() {
+        return Task.builder().build();
+    }
+}

--- a/plan-service/src/main/resources/application-test.yml
+++ b/plan-service/src/main/resources/application-test.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8001
-
 spring:
   jpa:
     hibernate:

--- a/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
@@ -1,0 +1,105 @@
+package com.example.planservice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@SuppressWarnings("squid:S5778")
+class PlanMembershipVerificationServiceTest {
+    @Autowired
+    PlanMembershipVerificationService service;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Autowired
+    MemberOfPlanRepository memberOfPlanRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버가 플랜에 소속되어 있으면 정상적으로 플랜을 반환한다")
+    void verifySuccess() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+        createMemberOfPlan(plan, member);
+
+        // when
+        Plan result = service.verifyAndReturnPlan(plan.getId(), member.getId());
+
+        // then
+        assertThat(result.getId()).isEqualTo(plan.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜에 대해서는 예외를 반환한다")
+    void verifyFailPlanNotFound() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> service.verifyAndReturnPlan(123123L, member.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("플랜에 소속되어 있지 않는 멤버에 대해서는 예외를 반환한다")
+    void verifyFailMemberNotExistInPlan() {
+        // given
+        Plan plan = createPlan();
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> service.verifyAndReturnPlan(plan.getId(), member.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
+    }
+
+    @NotNull
+    private MemberOfPlan createMemberOfPlan(Plan plan, Member member) {
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member)
+            .build();
+        memberOfPlanRepository.save(memberOfPlan);
+        return memberOfPlan;
+    }
+
+    @NotNull
+    private Member createMember() {
+        Member member = Member.builder()
+            .build();
+        memberRepository.save(member);
+        return member;
+    }
+
+    @NotNull
+    private Plan createPlan() {
+        Plan plan = Plan.builder().build();
+        planRepository.save(plan);
+        return plan;
+    }
+
+}

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -55,6 +55,7 @@ class TabServiceTest {
         Plan plan = createPlan();
         Member member = createMember();
         createMemberOfPlan(plan, member);
+        createTab(plan, "TODO", null, true);
 
         TabCreateRequest request = createTabCreateRequest(plan.getId(), "새로운탭");
 
@@ -127,7 +128,7 @@ class TabServiceTest {
         Member member = createMember();
         createMemberOfPlan(plan, member);
 
-        Tab tab1 = Tab.builder().plan(plan).build();
+        Tab tab1 = Tab.builder().first(true).plan(plan).build();
         Tab tab2 = Tab.builder().plan(plan).build();
         Tab tab3 = Tab.builder().plan(plan).build();
         Tab tab4 = Tab.builder().plan(plan).build();
@@ -210,26 +211,6 @@ class TabServiceTest {
         Tab savedTab = tabRepository.findById(savedId).get();
         assertThat(tab2.getNext()).isEqualTo(savedTab);
         assertThat(savedTab.getNext()).isNull();
-    }
-
-    @Test
-    @DisplayName("플랜에 소속된 탭 중 last가 null인 탭은 한개 이상 존재할 수 없다")
-    void createFailLastTabOver1() {
-        // given
-        Plan plan = createPlan();
-        Member member = createMember();
-        createMemberOfPlan(plan, member);
-        Tab tab2 = createTab(plan, "탭2", null, false);
-        Tab tab1 = createTab(plan, "탭1", null, true);
-
-        tabRepository.saveAll(List.of(tab1, tab2));
-
-        TabCreateRequest request = createTabCreateRequest(plan.getId(), "이름");
-
-        // when & then
-        assertThatThrownBy(() -> tabService.create(member.getId(), request))
-            .isInstanceOf(ApiException.class)
-            .hasMessageContaining(ErrorCode.SERVER_ERROR.getMessage());
     }
 
     @Test

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -1,0 +1,219 @@
+package com.example.planservice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.TaskRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@SuppressWarnings("squid:S5778")
+class TaskServiceTest {
+    @Autowired
+    TaskService taskService;
+
+    @Autowired
+    TaskRepository taskRepository;
+
+    @Autowired
+    TabRepository tabRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Autowired
+    MemberOfPlanRepository memberOfPlanRepository;
+
+    @Test
+    @DisplayName("특정 탭의 첫 태스크를 생성한다")
+    void createTaskOrderFirst() {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+        Plan plan = createPlan();
+        createMemberOfPlan(plan, loginMember);
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .startDate(null)
+            .endDate(null)
+            .build();
+
+        // when
+        Long createdId = taskService.createTask(loginMember.getId(), request);
+
+        // then
+        Task task = taskRepository.findById(createdId).get();
+
+        assertThat(task.getId()).isEqualTo(createdId);
+        assertThat(task.getTab().getId()).isEqualTo(request.getTabId());
+        assertThat(task.getManager().getId()).isEqualTo(request.getManagerId());
+        assertThat(task.getName()).isEqualTo(request.getName());
+        assertThat(task.getDescription()).isEqualTo(request.getDescription());
+        assertThat(task.getStartDate()).isEqualTo(request.getStartDate());
+        assertThat(task.getEndDate()).isEqualTo(request.getEndDate());
+
+        assertThat(tab.getLastTask()).isEqualTo(task);
+    }
+
+    @Test
+    @DisplayName("특정 탭의 N번째 태스크를 생성한다(첫 번째가 아님)")
+    void createTaskOrderNotFirst() {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Task originalFirstTab = createTask();
+        Tab tab = createTabWithLastTask(originalFirstTab);
+        Plan plan = createPlan();
+        createMemberOfPlan(plan, loginMember);
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .startDate(null)
+            .endDate(null)
+            .build();
+
+        // when
+        Long createdId = taskService.createTask(loginMember.getId(), request);
+
+        // then
+        Task task = taskRepository.findById(createdId).get();
+
+        assertThat(task.getId()).isEqualTo(createdId);
+        assertThat(task.getTab().getId()).isEqualTo(request.getTabId());
+        assertThat(task.getManager().getId()).isEqualTo(request.getManagerId());
+        assertThat(task.getName()).isEqualTo(request.getName());
+        assertThat(task.getDescription()).isEqualTo(request.getDescription());
+        assertThat(task.getStartDate()).isEqualTo(request.getStartDate());
+        assertThat(task.getEndDate()).isEqualTo(request.getEndDate());
+
+        assertThat(task.getPrev()).isEqualTo(originalFirstTab);
+        assertThat(originalFirstTab.getNext()).isEqualTo(task);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜에는 태스크를 만들 수 없다")
+    void createFailNotExistPlan() {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(123123L)
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .startDate(null)
+            .endDate(null)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> taskService.createTask(loginMember.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("플랜에 속한 사람만 태스크를 만들 수 있다")
+    void createFailNotExistMemberInPlan() {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+        Plan plan = createPlan();
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .startDate(null)
+            .endDate(null)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> taskService.createTask(loginMember.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
+    }
+
+
+    private Plan createPlan() {
+        Plan plan = Plan.builder().build();
+        planRepository.save(plan);
+        return plan;
+    }
+
+    private Tab createTab() {
+        Tab tab = Tab.builder().build();
+        tabRepository.save(tab);
+        return tab;
+    }
+
+    private Tab createTabWithLastTask(Task lastTask) {
+        Tab tab = Tab.builder()
+            .lastTask(lastTask)
+            .build();
+        tabRepository.save(tab);
+        return tab;
+    }
+
+    private Member createMember() {
+        Member member = Member.builder().build();
+        memberRepository.save(member);
+        return member;
+    }
+
+    private Task createTask() {
+        Task task = Task.builder().build();
+        taskRepository.save(task);
+        return task;
+    }
+
+    @NotNull
+    private MemberOfPlan createMemberOfPlan(Plan plan, Member member) {
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member)
+            .build();
+        memberOfPlanRepository.save(memberOfPlan);
+        return memberOfPlan;
+    }
+
+}

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -3,6 +3,9 @@ package com.example.planservice.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +14,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.label.Label;
+import com.example.planservice.domain.label.repository.LabelRepository;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -19,7 +24,9 @@ import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.LabelOfTask;
 import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.LabelOfTaskRepository;
 import com.example.planservice.domain.task.repository.TaskRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
@@ -48,6 +55,12 @@ class TaskServiceTest {
     @Autowired
     MemberOfPlanRepository memberOfPlanRepository;
 
+    @Autowired
+    LabelRepository labelRepository;
+
+    @Autowired
+    LabelOfTaskRepository labelOfTaskRepository;
+
     @Test
     @DisplayName("특정 탭의 첫 태스크를 생성한다")
     void createTaskOrderFirst() {
@@ -66,6 +79,7 @@ class TaskServiceTest {
             .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
             .startDate(null)
             .endDate(null)
+            .labels(Collections.emptyList())
             .build();
 
         // when
@@ -104,6 +118,7 @@ class TaskServiceTest {
             .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
             .startDate(null)
             .endDate(null)
+            .labels(Collections.emptyList())
             .build();
 
         // when
@@ -125,6 +140,114 @@ class TaskServiceTest {
     }
 
     @Test
+    @DisplayName("태스크는 라벨을 달고 생성할 수 있다")
+    void testCreateTaskWithLabels() {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+        Plan plan = createPlan();
+        createMemberOfPlan(plan, loginMember);
+        Label label1 = createLabelUsingTest(plan);
+        Label label2 = createLabelUsingTest(plan);
+        Label notUsingLabel = createLabelUsingTest(plan);
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .labels(List.of(label1.getId(), label2.getId()))
+            .build();
+
+        // when
+        Long createdId = taskService.createTask(loginMember.getId(), request);
+
+        // then
+        List<Label> labels = labelOfTaskRepository.findAll().stream()
+            .filter(labelOfTask -> labelOfTask.getTask().getId() == createdId)
+            .map(LabelOfTask::getLabel)
+            .toList();
+        assertThat(labels).hasSize(2)
+            .contains(label1, label2);
+
+        Task task = taskRepository.findById(createdId).get();
+        assertThat(task.getId()).isEqualTo(createdId);
+    }
+
+    @Test
+    @DisplayName("태스크를 만들 때 존재하지 않는 라벨을 달아도, 존재하는 라벨들만 사용해서 LabelOfTask를 만든다")
+    void testCreateTaskFailLabelNotFound() throws Exception {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+        Plan plan = createPlan();
+        createMemberOfPlan(plan, loginMember);
+        Label label1 = createLabelUsingTest(plan);
+        Long notRegisteredLabelId = 123123L;
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .labels(List.of(label1.getId(), notRegisteredLabelId))
+            .build();
+
+        // when
+        Long createdId = taskService.createTask(loginMember.getId(), request);
+
+        // then
+        List<Label> labels = labelOfTaskRepository.findAll().stream()
+            .filter(labelOfTask -> labelOfTask.getTask().getId() == createdId)
+            .map(LabelOfTask::getLabel)
+            .toList();
+        assertThat(labels).hasSize(1)
+            .contains(label1);
+
+        Task task = taskRepository.findById(createdId).get();
+        assertThat(task.getId()).isEqualTo(createdId);
+    }
+
+    @Test
+    @DisplayName("태스크를 만들 때 다른 플랜의 라벨을 달면, 우리 플랜에 존재하는 라벨만 사용해서 LabelOfTask를 만든다")
+    void testCreateTaskFailLabelNotFoundThisPlan() throws Exception {
+        // given
+        Member loginMember = createMember();
+        Member manager = createMember();
+        Tab tab = createTab();
+        Plan plan = createPlan();
+        Plan otherPlan = createPlan();
+        createMemberOfPlan(plan, loginMember);
+        Label otherPlansLabel = createLabelUsingTest(otherPlan);
+
+        TaskCreateRequest request = TaskCreateRequest.builder()
+            .planId(plan.getId())
+            .tabId(tab.getId())
+            .managerId(manager.getId())
+            .name("스프링공부하기")
+            .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
+            .labels(List.of(otherPlansLabel.getId()))
+            .build();
+
+        // when
+        Long createdId = taskService.createTask(loginMember.getId(), request);
+
+        // then
+        List<Label> labels = labelOfTaskRepository.findAll().stream()
+            .filter(labelOfTask -> labelOfTask.getTask().getId() == createdId)
+            .map(LabelOfTask::getLabel)
+            .toList();
+        assertThat(labels).isEmpty();
+
+        Task task = taskRepository.findById(createdId).get();
+        assertThat(task.getId()).isEqualTo(createdId);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 플랜에는 태스크를 만들 수 없다")
     void createFailNotExistPlan() {
         // given
@@ -140,6 +263,7 @@ class TaskServiceTest {
             .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
             .startDate(null)
             .endDate(null)
+            .labels(Collections.emptyList())
             .build();
 
         // when & then
@@ -165,6 +289,7 @@ class TaskServiceTest {
             .description("1. 책을 편다. \n2. 글자를 읽는다. \n3. 책을닫는다\n")
             .startDate(null)
             .endDate(null)
+            .labels(Collections.emptyList())
             .build();
 
         // when & then
@@ -173,6 +298,13 @@ class TaskServiceTest {
             .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
     }
 
+    private Label createLabelUsingTest(Plan plan) {
+        Label label = Label.builder()
+            .plan(plan)
+            .build();
+        labelRepository.save(label);
+        return label;
+    }
 
     private Plan createPlan() {
         Plan plan = Plan.builder().build();

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
@@ -193,8 +193,64 @@ class TabGroupTest {
             .hasMessageContaining(ErrorCode.TAB_NOT_FOUND_IN_PLAN.getMessage());
     }
 
+    @Test
+    @DisplayName("마지막에 탭을 추가한다")
+    void addLast() {
+        // given
+        Plan plan = createPlan();
+        Tab tab4 = createTab(plan, "탭4", null);
+        Tab tab3 = createTab(plan, "탭3", tab4);
+        Tab tab2 = createTab(plan, "탭2", tab3);
+        Tab tab1 = createTab(plan, "탭1", tab2);
 
-    @NotNull
+        Tab addedTab = Tab.builder().build();
+        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3, tab4));
+
+        // when
+        tabGroup.addLast(addedTab);
+
+        // then
+        assertThat(tab4.getNext()).isEqualTo(addedTab);
+        assertThat(addedTab.getNext()).isNull();
+    }
+
+    @Test
+    @DisplayName("탭그룹에는 개수 제한이 있다")
+    void addLastFailTabSizeLimit() {
+        // given
+        Plan plan = createPlan();
+        Tab tab5 = createTab(plan, "탭5", null);
+        Tab tab4 = createTab(plan, "탭4", tab5);
+        Tab tab3 = createTab(plan, "탭3", tab4);
+        Tab tab2 = createTab(plan, "탭2", tab3);
+        Tab tab1 = createTab(plan, "탭1", tab2);
+
+        Tab addedTab = Tab.builder().build();
+        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3, tab4, tab5));
+
+        // when & then
+        assertThatThrownBy(() -> tabGroup.addLast(addedTab))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TAB_SIZE_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("탭그룹에는 중복된 이름이 있을 수 없다")
+    void addLastFailTabNameDuplicated() {
+        // given
+        Plan plan = createPlan();
+        Tab tab1 = createTab(plan, "탭1", null);
+
+        Tab addedTab = Tab.builder().name("탭1").build();
+        TabGroup tabGroup = new TabGroup(plan, List.of(tab1));
+
+        // when & then
+        assertThatThrownBy(() -> tabGroup.addLast(addedTab))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TAB_NAME_DUPLICATE.getMessage());
+    }
+
+        @NotNull
     private Plan createPlan() {
         Plan plan = Plan.builder().build();
         planRepository.save(plan);

--- a/plan-service/src/test/java/com/example/planservice/domain/task/TaskTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/task/TaskTest.java
@@ -1,0 +1,38 @@
+package com.example.planservice.domain.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TaskTest {
+    @Test
+    @DisplayName("태스크를 서로 연결한다")
+    void connect() {
+        // given
+        Task task1 = createTask(null);
+        createTask(task1);
+        Task newTask = Task.builder().build();
+
+        // when
+        task1.connect(newTask);
+
+        // then
+        assertThat(task1.getNext()).isEqualTo(newTask);
+        assertThat(newTask.getPrev()).isEqualTo(task1);
+    }
+
+    @NotNull
+    private static Task createTask(Task prev) {
+        Task task2 = Task.builder()
+            .next(null)
+            .prev(prev)
+            .build();
+        if (prev != null) {
+            prev.setNext(task2);
+        }
+        return task2;
+    }
+
+}

--- a/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.example.planservice.domain.task.repository;
+
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class TaskRepositoryTest {
+    @Autowired
+    TaskRepository taskRepository;
+
+    @Autowired
+    TabRepository tabRepository;
+
+    @Test
+    @DisplayName("TabId에 해당하는 모든 태스크를 가져온다")
+    void findAllByTabId() {
+        // given
+        Tab tab = createTab();
+        Tab otherTab = createTab();
+        Task task1 = createTask(tab);
+        Task task2 = createTask(tab);
+        Task otherTask = createTask(otherTab);
+
+        // when
+        List<Task> result = taskRepository.findAllByTabId(tab.getId());
+
+        // then
+        assertThat(result).hasSize(2)
+            .contains(task1, task2);
+    }
+
+    private Tab createTab() {
+        Tab tab = Tab.builder().build();
+        tabRepository.save(tab);
+        return tab;
+    }
+
+    private Task createTask(Tab tab) {
+        Task task = Task.builder()
+            .tab(tab)
+            .build();
+        taskRepository.save(task);
+        return task;
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -30,7 +30,7 @@ import com.example.planservice.presentation.dto.request.TabCreateRequest;
 import com.example.planservice.presentation.dto.response.TabRetrieveResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest
+@WebMvcTest(controllers = {TabController.class})
 class TabControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
@@ -1,0 +1,66 @@
+package com.example.planservice.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.planservice.application.TaskService;
+import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = {TaskController.class})
+class TaskControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    TaskService taskService;
+
+    @Test
+    @DisplayName("태스크를 생성한다")
+    void createTask() throws Exception {
+        // given
+        TaskCreateRequest request = TaskCreateRequest.builder().build();
+        Long createdId = 1L;
+        Long userId = 2L;
+
+        // stub
+        Mockito.when(taskService.createTask(anyLong(), any(TaskCreateRequest.class)))
+            .thenReturn(createdId);
+
+        // when & then
+        mockMvc.perform(post("/tasks")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "/tasks/" + createdId))
+            .andExpect(redirectedUrlPattern("/tasks/*"));
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 태스크를 생성할 수 없다")
+    void createTaskFailNotLogin() throws Exception {
+        // given
+        TaskCreateRequest request = TaskCreateRequest.builder().build();
+
+        // when & then
+        mockMvc.perform(post("/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
📌 Description
태스크 생성 기능을 구현했습니다.
태스크는 생성될 때 Tab을 기준으로 가장 마지막에 생성됩니다.
개발 편의성을 위해 Tab에 lastTask라는 필드를 추가하여 양방향으로 만들어줬습니다.

또한 Doubly 링크드리스트 방식을 사용했습니다.
탭과 달리 태스크는 개수의 제한이 없습니다.
그래서 single 링크드리스트 방식을 사용하면 비효율적일거라 생각해 Doubly 방식으로 만들어줬습니다.

⚠️ 주의사항
원래 4주차 마일스톤에 태스크 관련 작업이 없었는데, 급하게 추가했습니다.
원래 이번 주차에 `탭을 삭제하는 기능`을 구현하기로 했습니다.
하지만 태스크에 대한 내용 없이 탭을 삭제하는 건 의미가 없다고 생각해서 `태스크 생성 기능` 을 먼저 구현했습니다.

close https://github.com/Side-Project-Planting/Backend/issues/26