### PR TITLE
[#25] 탭 삭제 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/PlanMembershipVerificationService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanMembershipVerificationService.java
@@ -1,7 +1,10 @@
 package com.example.planservice.application;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 
+import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
@@ -24,5 +27,13 @@ public class PlanMembershipVerificationService {
             throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
         }
         return plan;
+    }
+
+    public boolean validateOwner(Long planId, Long memberId) {
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        Member owner = plan.getOwner();
+        return Objects.equals(memberId, owner.getId());
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -90,7 +90,10 @@ public class TabService {
             throw new ApiException(ErrorCode.AUTHORIZATION_FAIL);
         }
 
-        tabRepository.delete(tab);
+        List<Tab> tabs = tabRepository.findAllByPlanId(plan.getId());
+        TabGroup tabGroup = new TabGroup(plan, tabs);
+        tabGroup.deleteById(tabId);
+        tabRepository.deleteById(tabId);
         return tabId;
     }
 

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.TabChangeNameResponse;
 import com.example.planservice.application.dto.TabChangeNameServiceRequest;
+import com.example.planservice.application.dto.TabDeleteServiceRequest;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.TabGroup;
@@ -80,7 +81,11 @@ public class TabService {
     }
 
     @Transactional
-    public Long delete(Long memberId, Long tabId, Long planId) {
+    public Long delete(TabDeleteServiceRequest request) {
+        Long planId = request.getPlanId();
+        Long tabId = request.getTabId();
+        Long memberId = request.getMemberId();
+
         boolean isAdmin = planMembershipVerificationService.validateOwner(planId, memberId);
         if (!isAdmin) {
             throw new ApiException(ErrorCode.AUTHORIZATION_FAIL);

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -79,6 +79,21 @@ public class TabService {
             .build();
     }
 
+    @Transactional
+    public Long delete(Long memberId, Long tabId) {
+        Tab tab = tabRepository.findById(tabId)
+            .orElseThrow(() -> new ApiException(ErrorCode.TAB_NOT_FOUND));
+        Plan plan = tab.getPlan();
+
+        boolean isAdmin = planMembershipVerificationService.validateOwner(plan.getId(), memberId);
+        if (!isAdmin) {
+            throw new ApiException(ErrorCode.AUTHORIZATION_FAIL);
+        }
+
+        tabRepository.delete(tab);
+        return tabId;
+    }
+
 
     @NotNull
     private Optional<Tab> findLastTab(List<Tab> tabsOfPlan) {

--- a/plan-service/src/main/java/com/example/planservice/application/dto/TabDeleteServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/TabDeleteServiceRequest.java
@@ -1,0 +1,20 @@
+package com.example.planservice.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TabDeleteServiceRequest {
+    private Long tabId;
+    private Long memberId;
+    private Long planId;
+
+    @Builder
+    private TabDeleteServiceRequest(Long tabId, Long memberId, Long planId) {
+        this.tabId = tabId;
+        this.memberId = memberId;
+        this.planId = planId;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
@@ -111,4 +111,20 @@ public class TabGroup {
             throw new ApiException(ErrorCode.PLAN_TAB_MISMATCH);
         }
     }
+
+    public void deleteById(Long tabId) {
+        List<Tab> sortedTabs = getSortedTabs();
+        Tab prev = sortedTabs.get(0);
+        if (Objects.equals(prev.getId(), tabId)) {
+            throw new ApiException(ErrorCode.TAB_CANNOT_DELETE);
+        }
+
+        for (Tab tab : sortedTabs) {
+            if (Objects.equals(tabId, tab.getId())) {
+                prev.connect(tab.getNext());
+                return;
+            }
+            prev = tab;
+        }
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/TabGroup.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import lombok.Getter;
@@ -21,8 +20,8 @@ public class TabGroup {
     @Getter
     private final Tab first;
 
-    public TabGroup(Plan plan, List<Tab> tabs) {
-        validate(plan, tabs);
+    public TabGroup(Long planId, List<Tab> tabs) {
+        validate(planId, tabs);
 
         this.hash = new HashMap<>();
         for (Tab tab : tabs) {
@@ -103,11 +102,11 @@ public class TabGroup {
         return result;
     }
 
-    private void validate(Plan plan, List<Tab> tabs) {
+    private void validate(Long planId, List<Tab> tabs) {
         if (tabs.isEmpty() || TAB_MAX_SIZE < tabs.size()) {
             throw new ApiException(ErrorCode.TAB_SIZE_INVALID);
         }
-        if (!Objects.equals(plan, tabs.get(0).getPlan())) {
+        if (!Objects.equals(planId, tabs.get(0).getPlan().getId())) {
             throw new ApiException(ErrorCode.PLAN_TAB_MISMATCH);
         }
     }

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
     REQUEST_CONFLICT(HttpStatus.CONFLICT, "요청들간 충돌이 발생했습니다. 다시 시도해 주세요"),
     PLAN_TAB_MISMATCH(HttpStatus.BAD_REQUEST, "플랜과 탭 사이 관계가 없습니다"),
     TARGET_TAB_SAME_AS_NEW_PREV(HttpStatus.BAD_REQUEST, "옮기려는 대상의 ID와 옮길 위치 이전에 위치한 탭의 ID는 동일할 수 없습니다"),
-    TAB_ORDER_FIXED(HttpStatus.BAD_REQUEST, "해당 탭은 순서를 변경할 수 없습니다");
+    TAB_ORDER_FIXED(HttpStatus.BAD_REQUEST, "해당 탭은 순서를 변경할 수 없습니다"),
+    AUTHORIZATION_FAIL(HttpStatus.FORBIDDEN, "해당되는 권한이 없습니다"),
+    TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다");
 
     private final HttpStatus status;
     private String message;

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     PLAN_TAB_MISMATCH(HttpStatus.BAD_REQUEST, "플랜과 탭 사이 관계가 없습니다"),
     TARGET_TAB_SAME_AS_NEW_PREV(HttpStatus.BAD_REQUEST, "옮기려는 대상의 ID와 옮길 위치 이전에 위치한 탭의 ID는 동일할 수 없습니다"),
     TAB_ORDER_FIXED(HttpStatus.BAD_REQUEST, "해당 탭은 순서를 변경할 수 없습니다"),
+    TAB_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "해당 탭은 삭제할 수 없습니다"),
     AUTHORIZATION_FAIL(HttpStatus.FORBIDDEN, "해당되는 권한이 없습니다"),
     TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다");
 

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.TabService;
 import com.example.planservice.application.dto.TabChangeNameResponse;
+import com.example.planservice.application.dto.TabDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.TabChangeNameRequest;
 import com.example.planservice.presentation.dto.request.TabChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
@@ -62,7 +63,12 @@ public class TabController {
     public ResponseEntity<Void> delete(@PathVariable(name = "id") Long tabId,
                                        @RequestAttribute Long userId,
                                        @RequestParam Long planId) {
-        tabService.delete(userId, tabId, planId);
+        TabDeleteServiceRequest request = TabDeleteServiceRequest.builder()
+            .tabId(tabId)
+            .memberId(userId)
+            .planId(planId)
+            .build();
+        tabService.delete(request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,5 +55,12 @@ public class TabController {
     public ResponseEntity<TabRetrieveResponse> retrieve(@PathVariable(name = "id") Long tabId,
                                                         @RequestAttribute Long userId) {
         return ResponseEntity.ok().body(tabService.retrieve(tabId, userId));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable(name = "id") Long tabId,
+                                       @RequestAttribute Long userId) {
+        tabService.delete(userId, tabId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.TabService;
@@ -59,8 +60,9 @@ public class TabController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable(name = "id") Long tabId,
-                                       @RequestAttribute Long userId) {
-        tabService.delete(userId, tabId);
+                                       @RequestAttribute Long userId,
+                                       @RequestParam Long planId) {
+        tabService.delete(userId, tabId, planId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
@@ -77,6 +77,37 @@ class PlanMembershipVerificationServiceTest {
             .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
     }
 
+    @Test
+    @DisplayName("해당 플랜의 소유주가 맞으면 validate 결과로 true를 반환한다")
+    void validateOwner() {
+        // given
+        Member member = createMember();
+        Plan plan = Plan.builder().owner(member).build();
+        planRepository.save(plan);
+
+        // when
+        boolean result = service.validateOwner(plan.getId(), member.getId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("해당 플랜의 소유주가 아니면 validate 결과로 false를 반환한다")
+    void validateOwnerFail() {
+        // given
+        Member member = createMember();
+        Member otherMember = createMember();
+        Plan plan = Plan.builder().owner(member).build();
+        planRepository.save(plan);
+
+        // when
+        boolean result = service.validateOwner(plan.getId(), otherMember.getId());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
     @NotNull
     private MemberOfPlan createMemberOfPlan(Plan plan, Member member) {
         MemberOfPlan memberOfPlan = MemberOfPlan.builder()

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -447,7 +447,7 @@ class TabServiceTest {
         createTab(plan, "TODO", target, true);
 
         // when
-        Long deletedId = tabService.delete(member.getId(), target.getId());
+        Long deletedId = tabService.delete(member.getId(), target.getId(), plan.getId());
 
         // then
         Optional<Tab> resultOpt = tabRepository.findById(deletedId);
@@ -465,7 +465,7 @@ class TabServiceTest {
         Tab first = createTab(plan, "TODO", second, true);
 
         // when
-        tabService.delete(member.getId(), second.getId());
+        tabService.delete(member.getId(), second.getId(), plan.getId());
 
         // then
         assertThat(first.getNext()).isEqualTo(third);
@@ -483,7 +483,7 @@ class TabServiceTest {
         Member otherMember = createMember();
 
         // when & then
-        assertThatThrownBy(() -> tabService.delete(otherMember.getId(), target.getId()))
+        assertThatThrownBy(() -> tabService.delete(otherMember.getId(), target.getId(), plan.getId()))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.AUTHORIZATION_FAIL.getMessage());
     }
@@ -500,7 +500,7 @@ class TabServiceTest {
         Task task = createTask(target);
 
         // when
-        tabService.delete(member.getId(), target.getId());
+        tabService.delete(member.getId(), target.getId(), plan.getId());
 
         // then
         List<Task> resultOpt = taskRepository.findAllByTabId(task.getId());

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -455,7 +455,24 @@ class TabServiceTest {
     }
 
     @Test
-    @DisplayName("플랜 소유자가 아니면 탭을 삭제할 수 있다")
+    @DisplayName("탭 삭제 시 자신의 prev 탭과 next 탭을 연결한다")
+    void checkConnectingIfTabDelete() {
+        // given
+        Member member = createMember();
+        Plan plan = createPlanWithOwner(member);
+        Tab third = createTab(plan, "세번째", null, false);
+        Tab second = createTab(plan, "두번째", third, false);
+        Tab first = createTab(plan, "TODO", second, true);
+
+        // when
+        tabService.delete(member.getId(), second.getId());
+
+        // then
+        assertThat(first.getNext()).isEqualTo(third);
+    }
+
+    @Test
+    @DisplayName("플랜 소유자가 아니면 탭을 삭제할 수 없다")
     void deleteTabFailNotOwner() {
         // given
         Member member = createMember();

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,8 @@ import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.TaskRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TabChangeOrderRequest;
@@ -47,6 +50,9 @@ class TabServiceTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @Autowired
+    TaskRepository taskRepository;
 
     @Test
     @DisplayName("탭을 생성한다")
@@ -401,8 +407,7 @@ class TabServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(
-            () -> tabService.changeName(request))
+        assertThatThrownBy(() -> tabService.changeName(request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.TAB_NOT_FOUND_IN_PLAN.getMessage());
     }
@@ -432,6 +437,59 @@ class TabServiceTest {
             .hasMessageContaining(ErrorCode.TAB_NAME_DUPLICATE.getMessage());
     }
 
+    @Test
+    @DisplayName("플랜 소유자는 탭을 삭제할 수 있다")
+    void deleteTab() {
+        // given
+        Member member = createMember();
+        Plan plan = createPlanWithOwner(member);
+        Tab target = createTab(plan, "두번째", null, false);
+        createTab(plan, "TODO", target, true);
+
+        // when
+        Long deletedId = tabService.delete(member.getId(), target.getId());
+
+        // then
+        Optional<Tab> resultOpt = tabRepository.findById(deletedId);
+        assertThat(resultOpt).isEmpty();
+    }
+
+    @Test
+    @DisplayName("플랜 소유자가 아니면 탭을 삭제할 수 있다")
+    void deleteTabFailNotOwner() {
+        // given
+        Member member = createMember();
+        Plan plan = createPlanWithOwner(member);
+        Tab target = createTab(plan, "두번째", null, false);
+        createTab(plan, "TODO", target, true);
+
+        Member otherMember = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> tabService.delete(otherMember.getId(), target.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZATION_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("탭이 삭제되면 해당 탭에 속해있던 모든 태스크가 함께 삭제된다")
+    void deleteAllRelatedTaskOnDeleteTab() {
+        // given
+        Member member = createMember();
+        Plan plan = createPlanWithOwner(member);
+        Tab target = createTab(plan, "두번째", null, false);
+        createTab(plan, "TODO", target, true);
+
+        Task task = createTask(target);
+
+        // when
+        tabService.delete(member.getId(), target.getId());
+
+        // then
+        List<Task> resultOpt = taskRepository.findAllByTabId(task.getId());
+        assertThat(resultOpt).isEmpty();
+    }
+
 
     private Tab createTab(Plan plan, String name, Tab next, boolean isFirst) {
         Tab tab = Tab.builder()
@@ -456,6 +514,13 @@ class TabServiceTest {
     }
 
     @NotNull
+    private Task createTask(Tab tab) {
+        Task task = Task.builder().tab(tab).build();
+        taskRepository.save(task);
+        return task;
+    }
+
+    @NotNull
     private Member createMember() {
         Member member = Member.builder()
             .build();
@@ -469,6 +534,14 @@ class TabServiceTest {
         planRepository.save(plan);
         return plan;
     }
+
+    @NotNull
+    private Plan createPlanWithOwner(Member owner) {
+        Plan plan = Plan.builder().owner(owner).build();
+        planRepository.save(plan);
+        return plan;
+    }
+
 
     @NotNull
     private TabCreateRequest createTabCreateRequest(Long planId, String name) {

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
@@ -250,7 +250,39 @@ class TabGroupTest {
             .hasMessageContaining(ErrorCode.TAB_NAME_DUPLICATE.getMessage());
     }
 
-        @NotNull
+    @Test
+    @DisplayName("탭 삭제 시 자신의 prev탭과 next탭을 연결한다")
+    void checkConnectingIfTabDelete() {
+        // given
+        Plan plan = createPlan();
+        Tab third = createTab(plan, "세번째", null);
+        Tab second = createTab(plan, "두번째", third);
+        Tab first = createTab(plan, "TODO", second);
+        TabGroup tabGroup = new TabGroup(plan, List.of(first, second, third));
+
+        // when
+        tabGroup.deleteById(second.getId());
+
+        // then
+        assertThat(first.getNext()).isEqualTo(third);
+    }
+
+    @Test
+    @DisplayName("첫 번째 탭은 삭제할 수 없다")
+    void cannotDeleteFirstTab() {
+        // given
+        Plan plan = createPlan();
+        Tab tab1 = createTab(plan, "TODO", null);
+        TabGroup tabGroup = new TabGroup(plan, List.of(tab1));
+
+        // when
+        assertThatThrownBy(() -> tabGroup.deleteById(tab1.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TAB_CANNOT_DELETE.getMessage());
+    }
+
+
+    @NotNull
     private Plan createPlan() {
         Plan plan = Plan.builder().build();
         planRepository.save(plan);

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
@@ -43,7 +43,7 @@ class TabGroupTest {
         Tab tab1 = createTab(plan, "탭1", tab2);
 
         // when
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3, tab4, tab5));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4, tab5));
 
         // then
         assertThat(tabGroup.getFirst()).isEqualTo(tab1);
@@ -67,7 +67,7 @@ class TabGroupTest {
         Tab tab1 = createTab(plan, "탭1", tab2);
 
         // when & then
-        assertThatThrownBy(() -> new TabGroup(plan, List.of(tab1, tab2, tab3, tab4, tab5, tab6)))
+        assertThatThrownBy(() -> new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4, tab5, tab6)))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.TAB_SIZE_INVALID.getMessage());
     }
@@ -79,7 +79,7 @@ class TabGroupTest {
         Plan plan = createPlan();
 
         // when & then
-        assertThatThrownBy(() -> new TabGroup(plan, Collections.emptyList()))
+        assertThatThrownBy(() -> new TabGroup(plan.getId(), Collections.emptyList()))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.TAB_SIZE_INVALID.getMessage());
     }
@@ -98,7 +98,7 @@ class TabGroupTest {
         Plan otherPlan = createPlan();
 
         // when & then
-        assertThatThrownBy(() -> new TabGroup(otherPlan, List.of(tab1, tab2, tab3, tab4)))
+        assertThatThrownBy(() -> new TabGroup(otherPlan.getId(), List.of(tab1, tab2, tab3, tab4)))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.PLAN_TAB_MISMATCH.getMessage());
     }
@@ -113,7 +113,7 @@ class TabGroupTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> new TabGroup(plan, List.of(tab)))
+        assertThatThrownBy(() -> new TabGroup(plan.getId(), List.of(tab)))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.SERVER_ERROR.getMessage());
     }
@@ -126,7 +126,7 @@ class TabGroupTest {
         Tab tab3 = createTab(plan, "탭3", null);
         Tab tab2 = createTab(plan, "탭2", tab3);
         Tab tab1 = createTab(plan, "탭1", tab2);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3));
 
         // when
         List<Tab> tabs = tabGroup.changeOrder(tab3.getId(), tab1.getId());
@@ -142,7 +142,7 @@ class TabGroupTest {
         Tab tab3 = createTab(plan, "탭3", null);
         Tab tab2 = createTab(plan, "탭2", tab3);
         Tab tab1 = createTab(plan, "탭1", tab2);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3));
 
         // when
         assertThatThrownBy(() -> tabGroup.changeOrder(tab1.getId(), tab2.getId()))
@@ -158,7 +158,7 @@ class TabGroupTest {
         Tab tab3 = createTab(plan, "탭3", null);
         Tab tab2 = createTab(plan, "탭2", tab3);
         Tab tab1 = createTab(plan, "탭1", tab2);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3));
 
         // when & then
         assertThatThrownBy(() -> tabGroup.changeOrder(tab2.getId(), tab2.getId()))
@@ -172,7 +172,7 @@ class TabGroupTest {
         // given
         Plan plan = createPlan();
         Tab tab = createTab(plan, "탭", null);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab));
 
         assertThat(tabGroup.findById(tab.getId())).isEqualTo(tab);
     }
@@ -183,7 +183,7 @@ class TabGroupTest {
         // given
         Plan plan = createPlan();
         Tab tab = createTab(plan, "탭", null);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab));
 
         Tab otherTab = createTab(null, "다른탭", null);
 
@@ -204,7 +204,7 @@ class TabGroupTest {
         Tab tab1 = createTab(plan, "탭1", tab2);
 
         Tab addedTab = Tab.builder().build();
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3, tab4));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4));
 
         // when
         tabGroup.addLast(addedTab);
@@ -226,7 +226,7 @@ class TabGroupTest {
         Tab tab1 = createTab(plan, "탭1", tab2);
 
         Tab addedTab = Tab.builder().build();
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1, tab2, tab3, tab4, tab5));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4, tab5));
 
         // when & then
         assertThatThrownBy(() -> tabGroup.addLast(addedTab))
@@ -242,7 +242,7 @@ class TabGroupTest {
         Tab tab1 = createTab(plan, "탭1", null);
 
         Tab addedTab = Tab.builder().name("탭1").build();
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1));
 
         // when & then
         assertThatThrownBy(() -> tabGroup.addLast(addedTab))
@@ -258,7 +258,7 @@ class TabGroupTest {
         Tab third = createTab(plan, "세번째", null);
         Tab second = createTab(plan, "두번째", third);
         Tab first = createTab(plan, "TODO", second);
-        TabGroup tabGroup = new TabGroup(plan, List.of(first, second, third));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(first, second, third));
 
         // when
         tabGroup.deleteById(second.getId());
@@ -273,7 +273,7 @@ class TabGroupTest {
         // given
         Plan plan = createPlan();
         Tab tab1 = createTab(plan, "TODO", null);
-        TabGroup tabGroup = new TabGroup(plan, List.of(tab1));
+        TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1));
 
         // when
         assertThatThrownBy(() -> tabGroup.deleteById(tab1.getId()))

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -218,7 +218,7 @@ class TabControllerTest {
 
     @Test
     @DisplayName("인증되지 않은 사용자는 Tab의 순서를 변경할 수 없다")
-    void changeTabOrderFailNotAuthorized() throws Exception {
+    void changeTabOrderFailNotAuthenticated() throws Exception {
         // given
         TabChangeOrderRequest request = TabChangeOrderRequest.builder().build();
 
@@ -261,7 +261,7 @@ class TabControllerTest {
 
     @Test
     @DisplayName("인증되지 않은 사용자는 Tab의 이름을 변경할 수 없다")
-    void changeTabNameFailNotAuthorized() throws Exception {
+    void changeTabNameFailNotAuthenticated() throws Exception {
         // given
         TabChangeNameRequest request = TabChangeNameRequest.builder().build();
         TabChangeNameResponse response = TabChangeNameResponse.builder().build();
@@ -274,6 +274,35 @@ class TabControllerTest {
         mockMvc.perform(patch("/tabs/1/name")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("탭 삭제에 성공하면 204 상태를 반환한다")
+    void deleteTab() throws Exception {
+        // given
+        Long userId = 1L;
+        Long tabId = 2L;
+
+        // stub
+        when(tabService.delete(userId, tabId))
+            .thenReturn(tabId);
+
+        // when & then
+        mockMvc.perform(delete("/tabs/" + tabId)
+                .header("X-User-Id", userId))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("탭 삭제는 로그인한 사용자만이 가능하다")
+    void deleteTabFailNotAuthenticated() throws Exception {
+        // given
+        Long userId = 1L;
+        Long tabId = 2L;
+
+        // when & then
+        mockMvc.perform(delete("/tabs/" + tabId))
             .andExpect(status().isUnauthorized());
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.example.planservice.application.TabService;
 import com.example.planservice.application.dto.TabChangeNameResponse;
 import com.example.planservice.application.dto.TabChangeNameServiceRequest;
+import com.example.planservice.application.dto.TabDeleteServiceRequest;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TabChangeNameRequest;
@@ -286,7 +287,7 @@ class TabControllerTest {
         Long planId = 3L;
 
         // stub
-        when(tabService.delete(userId, tabId, planId))
+        when(tabService.delete(any(TabDeleteServiceRequest.class)))
             .thenReturn(tabId);
 
         // when & then

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -283,13 +283,14 @@ class TabControllerTest {
         // given
         Long userId = 1L;
         Long tabId = 2L;
+        Long planId = 3L;
 
         // stub
-        when(tabService.delete(userId, tabId))
+        when(tabService.delete(userId, tabId, planId))
             .thenReturn(tabId);
 
         // when & then
-        mockMvc.perform(delete("/tabs/" + tabId)
+        mockMvc.perform(delete("/tabs/" + tabId + "?planId=" + planId)
                 .header("X-User-Id", userId))
             .andExpect(status().isNoContent());
     }
@@ -298,11 +299,11 @@ class TabControllerTest {
     @DisplayName("탭 삭제는 로그인한 사용자만이 가능하다")
     void deleteTabFailNotAuthenticated() throws Exception {
         // given
-        Long userId = 1L;
         Long tabId = 2L;
+        Long planId = 3L;
 
         // when & then
-        mockMvc.perform(delete("/tabs/" + tabId))
+        mockMvc.perform(delete("/tabs/" + tabId + "?planId=" + planId))
             .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
📌 Description
탭 삭제 시 연관된 태스크가 전부 삭제되도록 구현했습니다.
이번에도 TabGroup 일급콜렉션을 사용했습니다.
특정 객체가 삭제되면 해당 객체의 prev와 next가 연결되도록 만들었습니다.

⚠️ 주의사항
없습니다.

close #25 