### PR TITLE
[#60] auth service README 복구

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,18 @@
+## AUTH-SERVICE DOCKER 사용법
+
+### 1. gradle 8.2 version 설치
+
+### 2. yml파일 작성
+
+https://github.com/Side-Project-Planting/Backend/pull/11
+참고
+
+### 3. jar 파일 빌드
+
+auth-service 경로에서 실행
+> ./gradlew build -x test
+### 4. Docker 실행
+
+auth-service 경로에서 실행
+> docker-compose up
+


### PR DESCRIPTION
📌 Description
브랜치를 병합하는 과정에서 README가 날아갔습니다.

두 개의 브랜치를 연속으로 병합할 때 꼭 fetch & merge를 해야겠습니다.
이전 브랜치에서 생성한 파일이 날아갈 수도 있다는 걸 몰랐습니다.

작업이 날아간 브랜치는 https://github.com/Side-Project-Planting/Backend/pull/40 입니다.

⚠️ 주의사항
README 이외에 다른 변경사항(Dockerfile, docker-compose.yml)은 최신화가 되어있어 README만 복구했습니다.

close https://github.com/Side-Project-Planting/Backend/issues/60