### PR TITLE
[#62, #63] 라벨 생성, 삭제 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/LabelService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/LabelService.java
@@ -29,11 +29,7 @@ public class LabelService {
             throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
         }
 
-        Label label = Label.builder()
-            .name(name)
-            .plan(plan)
-            .build();
-
+        Label label = Label.create(name, plan);
         Label savedEntity = labelRepository.save(label);
         return savedEntity.getId();
     }

--- a/plan-service/src/main/java/com/example/planservice/application/LabelService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/LabelService.java
@@ -1,0 +1,40 @@
+package com.example.planservice.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.label.Label;
+import com.example.planservice.domain.label.repository.LabelRepository;
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LabelService {
+    private final LabelRepository labelRepository;
+    private final PlanRepository planRepository;
+    private final MemberOfPlanRepository memberOfPlanRepository;
+
+    @Transactional
+    public Long create(String name, Long planId, Long memberId) {
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        boolean isExists = memberOfPlanRepository.existsByPlanIdAndMemberId(planId, memberId);
+        if (!isExists) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
+        }
+
+        Label label = Label.builder()
+            .name(name)
+            .plan(plan)
+            .build();
+
+        Label savedEntity = labelRepository.save(label);
+        return savedEntity.getId();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/application/LabelService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/LabelService.java
@@ -10,6 +10,7 @@ import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,7 +22,10 @@ public class LabelService {
     private final MemberOfPlanRepository memberOfPlanRepository;
 
     @Transactional
-    public Long create(String name, Long planId, Long memberId) {
+    public Long create(Long memberId, LabelCreateRequest request) {
+        Long planId = request.getPlanId();
+        String name = request.getName();
+
         Plan plan = planRepository.findById(planId)
             .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         boolean isExists = memberOfPlanRepository.existsByPlanIdAndMemberId(planId, memberId);

--- a/plan-service/src/main/java/com/example/planservice/application/LabelService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/LabelService.java
@@ -9,9 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.label.repository.LabelRepository;
-import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
 import com.example.planservice.domain.plan.Plan;
-import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.LabelCreateRequest;
@@ -22,21 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LabelService {
     private final LabelRepository labelRepository;
-    private final PlanRepository planRepository;
-    private final MemberOfPlanRepository memberOfPlanRepository;
     private final PlanMembershipVerificationService planMembershipVerificationService;
 
     @Transactional
     public Long create(Long memberId, LabelCreateRequest request) {
-        Long planId = request.getPlanId();
-        String name = request.getName();
-        Plan plan = planRepository.findById(planId)
-            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        Plan plan = planMembershipVerificationService.verifyAndReturnPlan(request.getPlanId(), memberId);
 
-        boolean existMemberInPlan = memberOfPlanRepository.existsByPlanIdAndMemberId(planId, memberId);
-        if (!existMemberInPlan) {
-            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN);
-        }
+        String name = request.getName();
         if (plan.existsDuplicatedLabelName(name)) {
             throw new ApiException(ErrorCode.LABEL_NAME_DUPLICATE);
         }

--- a/plan-service/src/main/java/com/example/planservice/application/dto/LabelDeleteServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/LabelDeleteServiceRequest.java
@@ -1,0 +1,20 @@
+package com.example.planservice.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LabelDeleteServiceRequest {
+    private Long labelId;
+    private Long memberId;
+    private Long planId;
+
+    @Builder
+    private LabelDeleteServiceRequest(Long labelId, Long memberId, Long planId) {
+        this.labelId = labelId;
+        this.memberId = memberId;
+        this.planId = planId;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -11,15 +11,19 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "labels")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "labels",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UniquePlanAndLabelName", columnNames = {"plan_id", "name"})
+    })
 public class Label extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/Label.java
@@ -37,4 +37,11 @@ public class Label extends BaseEntity {
         this.plan = plan;
         this.name = name;
     }
+
+    public static Label create(String name, Plan plan) {
+        return Label.builder()
+            .name(name)
+            .plan(plan)
+            .build();
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/label/repository/LabelRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/label/repository/LabelRepository.java
@@ -1,8 +1,10 @@
 package com.example.planservice.domain.label.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
 import com.example.planservice.domain.label.Label;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
+@Repository
 public interface LabelRepository extends JpaRepository<Label, Long> {
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -70,4 +70,8 @@ public class Plan extends BaseEntity {
         return labels.stream()
             .anyMatch(label -> Objects.equals(label.getName(), name));
     }
+
+    public void remove(Label label) {
+        labels.remove(label);
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -1,8 +1,13 @@
 package com.example.planservice.domain.plan;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import org.hibernate.annotations.Where;
 
 import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,6 +51,9 @@ public class Plan extends BaseEntity {
 
     private boolean isDeleted;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    private List<Label> labels = new ArrayList<>();
+
     @Builder
     private Plan(Member owner, String title, String intro, boolean isPublic, int starCnt, int viewCnt,
                  boolean isDeleted) {
@@ -55,5 +64,10 @@ public class Plan extends BaseEntity {
         this.starCnt = starCnt;
         this.viewCnt = viewCnt;
         this.isDeleted = isDeleted;
+    }
+
+    public boolean existsDuplicatedLabelName(String name) {
+        return labels.stream()
+            .anyMatch(label -> Objects.equals(label.getName(), name));
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     TAB_ORDER_FIXED(HttpStatus.BAD_REQUEST, "해당 탭은 순서를 변경할 수 없습니다"),
     TAB_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "해당 탭은 삭제할 수 없습니다"),
     AUTHORIZATION_FAIL(HttpStatus.FORBIDDEN, "해당되는 권한이 없습니다"),
-    TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다");
+    TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다"),
+    LABEL_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "라벨 이름이 중복되었습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     TAB_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "해당 탭은 삭제할 수 없습니다"),
     AUTHORIZATION_FAIL(HttpStatus.FORBIDDEN, "해당되는 권한이 없습니다"),
     TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다"),
-    LABEL_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "라벨 이름이 중복되었습니다");
+    LABEL_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "라벨 이름이 중복되었습니다"),
+    LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, "라벨이 존재하지 않습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
@@ -23,7 +23,7 @@ public class LabelController {
     @PostMapping
     ResponseEntity<Void> create(@RequestBody @Valid LabelCreateRequest labelCreateRequest,
                                 @RequestAttribute Long userId) {
-        Long createdId = labelService.create(labelCreateRequest.getName(), labelCreateRequest.getPlanId(), userId);
+        Long createdId = labelService.create(userId, labelCreateRequest);
         return ResponseEntity.created(URI.create("/labels/" + createdId)).build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
@@ -3,13 +3,17 @@ package com.example.planservice.presentation;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.LabelService;
+import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +29,19 @@ public class LabelController {
                                 @RequestAttribute Long userId) {
         Long createdId = labelService.create(userId, labelCreateRequest);
         return ResponseEntity.created(URI.create("/labels/" + createdId)).build();
+    }
+
+    @DeleteMapping("/{labelId}")
+    ResponseEntity<Void> delete(@PathVariable Long labelId,
+                                @RequestParam Long planId,
+                                @RequestAttribute Long userId) {
+        LabelDeleteServiceRequest request = LabelDeleteServiceRequest.builder()
+            .labelId(labelId)
+            .planId(planId)
+            .memberId(userId)
+            .build();
+
+        labelService.delete(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
@@ -1,0 +1,29 @@
+package com.example.planservice.presentation;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.planservice.application.LabelService;
+import com.example.planservice.presentation.dto.request.LabelCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/labels")
+@RequiredArgsConstructor
+public class LabelController {
+    private final LabelService labelService;
+
+    @PostMapping
+    ResponseEntity<Void> create(@RequestBody @Valid LabelCreateRequest labelCreateRequest,
+                                @RequestAttribute Long userId) {
+        Long createdId = labelService.create(labelCreateRequest.getName(), labelCreateRequest.getPlanId(), userId);
+        return ResponseEntity.created(URI.create("/labels/" + createdId)).build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/LabelCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/LabelCreateRequest.java
@@ -1,0 +1,18 @@
+package com.example.planservice.presentation.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LabelCreateRequest {
+    private String name;
+    private Long planId;
+
+    @Builder
+    private LabelCreateRequest(String name, Long planId) {
+        this.name = name;
+        this.planId = planId;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/LabelCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/LabelCreateRequest.java
@@ -1,5 +1,7 @@
 package com.example.planservice.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,7 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class LabelCreateRequest {
+    @NotBlank
     private String name;
+
+    @NotNull
     private Long planId;
 
     @Builder

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -16,6 +16,7 @@ import com.example.planservice.domain.memberofplan.MemberOfPlan;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
@@ -36,8 +37,13 @@ class LabelServiceTest {
         Plan plan = createPlanUsingTest();
         Member member = createMemberWithPlanUsingTest(plan);
 
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .planId(plan.getId())
+            .name(name)
+            .build();
+
         // when
-        Long createdId = labelService.create(name, plan.getId(), member.getId());
+        Long createdId = labelService.create(member.getId(), request);
 
         // then
         Label result = em.find(Label.class, createdId);
@@ -51,8 +57,13 @@ class LabelServiceTest {
         String name = "라벨1";
         Member member = createMemberWithPlanUsingTest(null);
 
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .planId(1231412L)
+            .name(name)
+            .build();
+
         // when & then
-        assertThatThrownBy(() -> labelService.create(name, 123456L, member.getId()))
+        assertThatThrownBy(() -> labelService.create(member.getId(), request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
     }
@@ -65,8 +76,13 @@ class LabelServiceTest {
         Plan plan = createPlanUsingTest();
         Member member = createMemberWithPlanUsingTest(null);
 
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .planId(plan.getId())
+            .name(name)
+            .build();
+
         // when & then
-        assertThatThrownBy(() -> labelService.create(name, plan.getId(), member.getId()))
+        assertThatThrownBy(() -> labelService.create(member.getId(), request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
     }

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.planservice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.planservice.domain.label.Label;
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class LabelServiceTest {
+    @Autowired
+    LabelService labelService;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("라벨을 생성한다")
+    void testCreateLabel() throws Exception {
+        // given
+        String name = "라벨1";
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberWithPlanUsingTest(plan);
+
+        // when
+        Long createdId = labelService.create(name, plan.getId(), member.getId());
+
+        // then
+        Label result = em.find(Label.class, createdId);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("라벨에는 플랜이 포함되어야 한다")
+    void testCreateLabelFailPlanNotFound() throws Exception {
+        // given
+        String name = "라벨1";
+        Member member = createMemberWithPlanUsingTest(null);
+
+        // when & then
+        assertThatThrownBy(() -> labelService.create(name, 123456L, member.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("플랜에 소속된 멤버만 라벨을 생성할 수 있다")
+    void testCreateLabelFailMemberNotExistPlan() throws Exception {
+        // given
+        String name = "라벨1";
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberWithPlanUsingTest(null);
+
+        // when & then
+        assertThatThrownBy(() -> labelService.create(name, plan.getId(), member.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
+    }
+
+    private Member createMemberWithPlanUsingTest(Plan plan) {
+        Member member = Member.builder().build();
+        em.persist(member);
+        if (plan == null) {
+            return member;
+        }
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member)
+            .build();
+        em.persist(memberOfPlan);
+        return member;
+    }
+
+    private Plan createPlanUsingTest() {
+        Plan plan = Plan.builder().build();
+        em.persist(plan);
+        return plan;
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -106,6 +107,92 @@ class LabelServiceTest {
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.LABEL_NAME_DUPLICATE.getMessage());
     }
+
+    @Test
+    @DisplayName("라벨을 삭제한다")
+    void testDeleteLabel() throws Exception {
+        // given
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberUsingTest(plan);
+        Label label = createLabelUsingTest("라벨명", plan);
+
+        LabelDeleteServiceRequest request = LabelDeleteServiceRequest.builder()
+            .labelId(label.getId())
+            .memberId(member.getId())
+            .planId(plan.getId())
+            .build();
+
+        // when
+        labelService.delete(request);
+
+        // then
+        Label result = em.find(Label.class, label.getId());
+        assertThat(result).isNull();
+        assertThat(plan.getLabels()).doesNotContain(label);
+    }
+
+    @Test
+    @DisplayName("플랜에 소속된 멤버만 라벨을 삭제할 수 있다")
+    void testDeleteLabelFailNoAuthorize() throws Exception {
+        // given
+        Plan plan = createPlanUsingTest();
+        Plan otherPlan = createPlanUsingTest();
+        Member member = createMemberUsingTest(otherPlan);
+        Label label = createLabelUsingTest("라벨명", plan);
+
+        LabelDeleteServiceRequest request = LabelDeleteServiceRequest.builder()
+            .planId(plan.getId())
+            .memberId(member.getId())
+            .labelId(label.getId())
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> labelService.delete(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
+    }
+
+    @Test
+    @DisplayName("라벨 삭제 시 입력받은 PlanId는 라벨의 Plan과 일치해야 한다")
+    void testDeleteLabelFailNotSamePlan() throws Exception {
+        // given
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberUsingTest(plan);
+
+        Plan otherPlan = createPlanUsingTest();
+        Label label = createLabelUsingTest("라벨명", otherPlan);
+
+        LabelDeleteServiceRequest request = LabelDeleteServiceRequest.builder()
+            .planId(plan.getId())
+            .memberId(member.getId())
+            .labelId(label.getId())
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> labelService.delete(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZATION_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 라벨을 삭제할 수 없다")
+    void testDeleteLabelFailNotExists() throws Exception {
+        // given
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberUsingTest(plan);
+
+        LabelDeleteServiceRequest request = LabelDeleteServiceRequest.builder()
+            .planId(plan.getId())
+            .memberId(member.getId())
+            .labelId(12312312L)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> labelService.delete(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.LABEL_NOT_FOUND.getMessage());
+    }
+
 
     private Label createLabelUsingTest(String name, Plan plan) {
         Label label = Label.create(name, plan);

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.LabelDeleteServiceRequest;
@@ -21,7 +20,6 @@ import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class LabelServiceTest {
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -35,7 +35,7 @@ class LabelServiceTest {
         // given
         String name = "라벨1";
         Plan plan = createPlanUsingTest();
-        Member member = createMemberWithPlanUsingTest(plan);
+        Member member = createMemberUsingTest(plan);
 
         LabelCreateRequest request = LabelCreateRequest.builder()
             .planId(plan.getId())
@@ -55,7 +55,7 @@ class LabelServiceTest {
     void testCreateLabelFailPlanNotFound() throws Exception {
         // given
         String name = "라벨1";
-        Member member = createMemberWithPlanUsingTest(null);
+        Member member = createMemberUsingTest(null);
 
         LabelCreateRequest request = LabelCreateRequest.builder()
             .planId(1231412L)
@@ -74,7 +74,7 @@ class LabelServiceTest {
         // given
         String name = "라벨1";
         Plan plan = createPlanUsingTest();
-        Member member = createMemberWithPlanUsingTest(null);
+        Member member = createMemberUsingTest(null);
 
         LabelCreateRequest request = LabelCreateRequest.builder()
             .planId(plan.getId())
@@ -87,7 +87,34 @@ class LabelServiceTest {
             .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN.getMessage());
     }
 
-    private Member createMemberWithPlanUsingTest(Plan plan) {
+    @Test
+    @DisplayName("하나의 플랜 안에서는 동일한 이름의 라벨이 등록될 수 없다")
+    void testCreateLabelFailNameDuplicated() throws Exception {
+        // given
+        String duplicatedName = "중복이름";
+        Plan plan = createPlanUsingTest();
+        Member member = createMemberUsingTest(plan);
+        createLabelUsingTest(duplicatedName, plan);
+
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .planId(plan.getId())
+            .name(duplicatedName)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> labelService.create(member.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.LABEL_NAME_DUPLICATE.getMessage());
+    }
+
+    private Label createLabelUsingTest(String name, Plan plan) {
+        Label label = Label.create(name, plan);
+        em.persist(label);
+        plan.getLabels().add(label);
+        return label;
+    }
+
+    private Member createMemberUsingTest(Plan plan) {
         Member member = Member.builder().build();
         em.persist(member);
         if (plan == null) {

--- a/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanMembershipVerificationServiceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.domain.member.Member;
@@ -21,9 +20,7 @@ import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
-@SuppressWarnings("squid:S5778")
 class PlanMembershipVerificationServiceTest {
     @Autowired
     PlanMembershipVerificationService service;

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.TabChangeNameResponse;
@@ -33,9 +32,7 @@ import com.example.planservice.presentation.dto.request.TabChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
-@SuppressWarnings("squid:S5778")
 class TabServiceTest {
     @Autowired
     TabService tabService;

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.domain.label.Label;
@@ -33,9 +32,7 @@ import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TaskCreateRequest;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
-@SuppressWarnings("squid:S5778")
 class TaskServiceTest {
     @Autowired
     TaskService taskService;

--- a/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
@@ -1,21 +1,20 @@
 package com.example.planservice.domain.memberofplan.repository;
 
-import com.example.planservice.domain.member.Member;
-import com.example.planservice.domain.member.repository.MemberRepository;
-import com.example.planservice.domain.memberofplan.MemberOfPlan;
-import com.example.planservice.domain.plan.Plan;
-import com.example.planservice.domain.plan.repository.PlanRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.plan.Plan;
+import com.example.planservice.domain.plan.repository.PlanRepository;
+
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class MemberOfPlanRepositoryTest {
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.domain.plan.Plan;
@@ -21,9 +20,7 @@ import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
-@SuppressWarnings("squid:S5778")
 class TabGroupTest {
     @Autowired
     PlanRepository planRepository;

--- a/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
@@ -1,23 +1,20 @@
 package com.example.planservice.domain.task.repository;
 
-import com.example.planservice.domain.tab.Tab;
-import com.example.planservice.domain.tab.repository.TabRepository;
-import com.example.planservice.domain.task.Task;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class TaskRepositoryTest {
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
+++ b/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
@@ -10,10 +10,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class AuthenticationInterceptorTest {
     AuthenticationInterceptor interceptor;
     MockHttpServletRequest request;

--- a/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
@@ -1,5 +1,7 @@
 package com.example.planservice.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -44,7 +46,7 @@ class LabelControllerTest {
             .build();
 
         // stub
-        when(labelService.create(labelName, planId, userId))
+        when(labelService.create(anyLong(), any(LabelCreateRequest.class)))
             .thenReturn(createdLabelId);
 
         // when & then

--- a/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
@@ -14,16 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.planservice.application.LabelService;
-import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = LabelController.class)
-@ActiveProfiles("test")
 class LabelControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
@@ -1,0 +1,76 @@
+package com.example.planservice.presentation;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.planservice.application.LabelService;
+import com.example.planservice.presentation.dto.request.LabelCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = LabelController.class)
+@ActiveProfiles("test")
+class LabelControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    LabelService labelService;
+
+    @Test
+    @DisplayName("라벨을 생성하면 201 상태를 반환한다")
+    void testCreateLabel() throws Exception {
+        // given
+        Long userId = 1L;
+        Long createdLabelId = 2L;
+        Long planId = 3L;
+        String labelName = "라벨명";
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .name(labelName)
+            .planId(planId)
+            .build();
+
+        // stub
+        when(labelService.create(labelName, planId, userId))
+            .thenReturn(createdLabelId);
+
+        // when & then
+        mockMvc.perform(post("/labels")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "/labels/" + createdLabelId));
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 라벨을 생성하면 401 상태를 반환한다")
+    void testCreateLabelFailNotLogin() throws Exception {
+        // given
+        Long planId = 3L;
+        String labelName = "라벨명";
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .name(labelName)
+            .planId(planId)
+            .build();
+
+        // when & then
+        mockMvc.perform(post("/labels")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
@@ -3,6 +3,7 @@ package com.example.planservice.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.planservice.application.LabelService;
+import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.LabelCreateRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -59,6 +61,56 @@ class LabelControllerTest {
     }
 
     @Test
+    @DisplayName("라벨을 생성할 때 이름을 입력해야만 한다")
+    void testCreateLabelFailEmptyName() throws Exception {
+        // given
+        Long userId = 1L;
+        Long createdLabelId = 2L;
+        Long planId = 3L;
+
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .name("")
+            .planId(planId)
+            .build();
+
+        // stub
+        when(labelService.create(anyLong(), any(LabelCreateRequest.class)))
+            .thenReturn(createdLabelId);
+
+        // when & then
+        mockMvc.perform(post("/labels")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("라벨을 생성할 때 플랜의 ID를 입력해야만 한다")
+    void testCreateLabelFailEmptyPlanId() throws Exception {
+        // given
+        String labelName = "이름";
+        Long userId = 1L;
+        Long createdLabelId = 2L;
+
+        LabelCreateRequest request = LabelCreateRequest.builder()
+            .name(labelName)
+            .planId(null)
+            .build();
+
+        // stub
+        when(labelService.create(anyLong(), any(LabelCreateRequest.class)))
+            .thenReturn(createdLabelId);
+
+        // when & then
+        mockMvc.perform(post("/labels")
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("로그인하지 않은 사용자가 라벨을 생성하면 401 상태를 반환한다")
     void testCreateLabelFailNotLogin() throws Exception {
         // given
@@ -74,5 +126,47 @@ class LabelControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("라벨을 삭제하면 204 상태를 반환한다")
+    void testDeleteLabel() throws Exception {
+        // given
+        Long userId = 1L;
+        Long labelId = 2L;
+        Long planId = 3L;
+
+        // when & then
+        mockMvc.perform(delete("/labels/" + labelId + "?planId=" + planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 라벨을 삭제하려 하면 401 상태를 반환한다")
+    void testDeleteLabelFailNotLogin() throws Exception {
+        // given
+        Long labelId = 2L;
+        Long planId = 3L;
+
+        // when & then
+        mockMvc.perform(delete("/labels/" + labelId + "?planId=" + planId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("라벨을 삭제하려면 해당 라벨이 속한 Plan의 ID를 함께 입력해야 한다")
+    void testDeleteLabelFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long labelId = 2L;
+
+        // when & then
+        mockMvc.perform(delete("/labels/" + labelId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
📌 Description
단순한 CRUD라 로직에 대한 설명은 생략하겠습니다.

1. 아래 이미지는 라벨을 생성하는 서비스 로직입니다.
<img width="841" alt="스크린샷 2023-10-24 오후 8 29 59" src="https://github.com/Side-Project-Planting/Backend/assets/67636607/0251a167-a3c8-4733-ace5-237e24380b1b">
Label 테이블에 planId와 name 둘 다 동일할 수 없게 제약조건을 설정했는데요.

이처럼 데이터 정합성에 대한 검사를 DB에게 위임할 때마다 아래 로직이 들어가는게 지저분하다고 느껴집니다.
다른 괜찮은 방법을 아신다면 가르쳐주시면 감사하겠습니다.

```
        try {
            labelRepository.flush();
        } catch (DataIntegrityViolationException e) {
            throw new ApiException(ErrorCode.REQUEST_CONFLICT);
        }
```


2. 테스트코드를 신경써서 봐주시면 감사하겠습니다. 점점 테스트를 작성하는 노하우가 생기는 거 같아 뿌듯하네요.

⚠️ 주의사항
없습니다.

close https://github.com/Side-Project-Planting/Backend/issues/62
close #63 
