### PR TITLE
[#34, #72] 플랜 조회, 초대 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ application-local.yml
 application-docker.yml
 /.env
 
+id_ed25519
+known_hosts
+
 .gradle
 !gradle/wrapper/gradle-wrapper.jar
 !**/**/build/

--- a/plan-service/src/main/java/com/example/planservice/application/LabelService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/LabelService.java
@@ -41,6 +41,6 @@ public class LabelService {
         label.validateBelongsToPlan(plan);
 
         labelRepository.delete(label);
-        plan.remove(label);
+        plan.removeLabel(label);
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -125,9 +125,7 @@ public class PlanService {
 
     private List<MemberOfPlanResponse> getMemberResponses(List<MemberOfPlan> members, Long ownerId) {
         return members.stream()
-            .map(member ->
-                MemberOfPlanResponse.toPlanResponse(member.getMember(), ownerId)
-            )
+            .map(member -> MemberOfPlanResponse.to(member.getMember(), ownerId))
             .toList();
     }
 
@@ -136,22 +134,20 @@ public class PlanService {
             .map(tab -> {
                 List<Task> tasksOfTab = tab.getTasks();
                 List<Long> taskOrder = orderByNext(tasksOfTab);
-                return TabOfPlanResponse.toPlanResponse(tab, taskOrder);
+                return TabOfPlanResponse.to(tab, taskOrder);
             })
             .toList();
     }
 
     private List<LabelOfPlanResponse> getLabelResponses(List<Label> labels) {
         return labels.stream()
-            .map(LabelOfPlanResponse::toPlanResponse
-            )
+            .map(LabelOfPlanResponse::to)
             .toList();
     }
 
     private List<TaskOfPlanResponse> getTaskResponses(List<Task> tasks) {
         return tasks.stream()
-            .map(TaskOfPlanResponse::toPlanResponse
-            )
+            .map(TaskOfPlanResponse::to)
             .toList();
     }
 

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -43,8 +43,9 @@ public class PlanService {
 
     @Transactional
     public Long create(PlanCreateRequest request, Long userId) {
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new ApiException(
-            ErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(
+                ErrorCode.MEMBER_NOT_FOUND));
         Plan plan = Plan.builder()
             .title(request.getTitle())
             .intro(request.getIntro())
@@ -52,7 +53,10 @@ public class PlanService {
             .owner(member)
             .build();
 
-        MemberOfPlan memberOfPlan = MemberOfPlan.builder().member(member).plan(plan).build();
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .member(member)
+            .plan(plan)
+            .build();
         memberOfPlanRepository.save(memberOfPlan);
 
         sendInviteMail(request.getInvitedEmails(), request.getTitle());
@@ -62,12 +66,13 @@ public class PlanService {
         return savedPlan.getId();
     }
 
-    @Transactional
     public PlanResponse getTotalPlanResponse(Long planId) {
-        Plan plan = planRepository.findById(planId).orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         List<Tab> tabList = tabRepository.findAllByPlanId(planId);
 
-        List<MemberOfPlanResponse> members = getMemberResponses(plan.getMembers(), plan.getOwner().getId());
+        List<MemberOfPlanResponse> members = getMemberResponses(plan.getMembers(), plan.getOwner()
+            .getId());
         List<LabelOfPlanResponse> labels = getLabelResponses(plan.getLabels());
         List<TaskOfPlanResponse> tasks = getTaskResponses(plan.getTasks());
         List<Long> tabOrder = orderByNext(tabList);
@@ -87,10 +92,15 @@ public class PlanService {
 
     @Transactional
     public Long inviteMember(Long planId, Long memberId) {
-        Plan plan = planRepository.findById(planId).orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         Member member =
-            memberRepository.findById(memberId).orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
-        MemberOfPlan memberOfPlan = MemberOfPlan.builder().member(member).plan(plan).build();
+            memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .member(member)
+            .plan(plan)
+            .build();
         memberOfPlanRepository.save(memberOfPlan);
         return memberOfPlan.getId();
     }
@@ -100,35 +110,49 @@ public class PlanService {
     }
 
     private void createDefaultTab(Plan plan) {
-        Tab firstTab = Tab.builder().name("ToDo").plan(plan).build();
-        Tab lastTab = Tab.builder().name("Done").plan(plan).build();
+        Tab firstTab = Tab.builder()
+            .name("ToDo")
+            .plan(plan)
+            .build();
+        Tab lastTab = Tab.builder()
+            .name("Done")
+            .plan(plan)
+            .build();
         firstTab.connect(lastTab);
         tabRepository.save(firstTab);
         tabRepository.save(lastTab);
     }
 
     private List<MemberOfPlanResponse> getMemberResponses(List<MemberOfPlan> members, Long ownerId) {
-        return members.parallelStream().map(member ->
-            new MemberOfPlanResponse().toPlanResponse(member.getMember(), ownerId)
-        ).toList();
+        return members.parallelStream()
+            .map(member ->
+                new MemberOfPlanResponse().toPlanResponse(member.getMember(), ownerId)
+            )
+            .toList();
     }
 
     private List<TabOfPlanResponse> getTabResponses(List<Tab> tabList) {
-        return tabList.parallelStream().map(tab -> {
-            List<Task> tasksOfTab = tab.getTasks();
-            List<Long> taskOrder = orderByNext(tasksOfTab);
-            return new TabOfPlanResponse().toPlanResponse(tab, taskOrder);
-        }).toList();
+        return tabList.parallelStream()
+            .map(tab -> {
+                List<Task> tasksOfTab = tab.getTasks();
+                List<Long> taskOrder = orderByNext(tasksOfTab);
+                return new TabOfPlanResponse().toPlanResponse(tab, taskOrder);
+            })
+            .toList();
     }
 
     private List<LabelOfPlanResponse> getLabelResponses(List<Label> labels) {
-        return labels.stream().map(label -> new LabelOfPlanResponse().toPlanResponse(label)
-        ).toList();
+        return labels.stream()
+            .map(label -> new LabelOfPlanResponse().toPlanResponse(label)
+            )
+            .toList();
     }
 
     private List<TaskOfPlanResponse> getTaskResponses(List<Task> tasks) {
-        return tasks.stream().map(task -> new TaskOfPlanResponse().toPlanResponse(task)
-        ).toList();
+        return tasks.stream()
+            .map(task -> new TaskOfPlanResponse().toPlanResponse(task)
+            )
+            .toList();
     }
 
     public <T extends Linkable<T>> List<Long> orderByNext(List<T> items) {
@@ -141,7 +165,8 @@ public class PlanService {
             }
         }
         if (!allNodes.isEmpty()) {
-            start = allNodes.iterator().next();
+            start = allNodes.iterator()
+                .next();
         }
 
         T current = start;

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -126,7 +126,7 @@ public class PlanService {
     private List<MemberOfPlanResponse> getMemberResponses(List<MemberOfPlan> members, Long ownerId) {
         return members.stream()
             .map(member ->
-                new MemberOfPlanResponse().toPlanResponse(member.getMember(), ownerId)
+                MemberOfPlanResponse.toPlanResponse(member.getMember(), ownerId)
             )
             .toList();
     }
@@ -136,21 +136,21 @@ public class PlanService {
             .map(tab -> {
                 List<Task> tasksOfTab = tab.getTasks();
                 List<Long> taskOrder = orderByNext(tasksOfTab);
-                return new TabOfPlanResponse().toPlanResponse(tab, taskOrder);
+                return TabOfPlanResponse.toPlanResponse(tab, taskOrder);
             })
             .toList();
     }
 
     private List<LabelOfPlanResponse> getLabelResponses(List<Label> labels) {
         return labels.stream()
-            .map(label -> new LabelOfPlanResponse().toPlanResponse(label)
+            .map(LabelOfPlanResponse::toPlanResponse
             )
             .toList();
     }
 
     private List<TaskOfPlanResponse> getTaskResponses(List<Task> tasks) {
         return tasks.stream()
-            .map(task -> new TaskOfPlanResponse().toPlanResponse(task)
+            .map(TaskOfPlanResponse::toPlanResponse
             )
             .toList();
     }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -124,7 +124,7 @@ public class PlanService {
     }
 
     private List<MemberOfPlanResponse> getMemberResponses(List<MemberOfPlan> members, Long ownerId) {
-        return members.parallelStream()
+        return members.stream()
             .map(member ->
                 new MemberOfPlanResponse().toPlanResponse(member.getMember(), ownerId)
             )
@@ -132,7 +132,7 @@ public class PlanService {
     }
 
     private List<TabOfPlanResponse> getTabResponses(List<Tab> tabList) {
-        return tabList.parallelStream()
+        return tabList.stream()
             .map(tab -> {
                 List<Task> tasksOfTab = tab.getTasks();
                 List<Long> taskOrder = orderByNext(tasksOfTab);

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -1,19 +1,30 @@
 package com.example.planservice.application;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.Linkable;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.response.LabelOfPlanResponse;
+import com.example.planservice.presentation.dto.response.MemberOfPlanResponse;
+import com.example.planservice.presentation.dto.response.PlanResponse;
+import com.example.planservice.presentation.dto.response.TabOfPlanResponse;
+import com.example.planservice.presentation.dto.response.TaskOfPlanResponse;
 import lombok.RequiredArgsConstructor;
 
 
@@ -45,6 +56,43 @@ public class PlanService {
         return savedPlan.getId();
     }
 
+    @Transactional
+    public PlanResponse getTotalPlanResponse(Long planId) {
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        List<MemberOfPlanResponse> members = plan.getMembers().parallelStream().map(member ->
+            new MemberOfPlanResponse().toPlanResponse(member.getMember(), plan.getOwner().getId())
+        ).toList();
+
+        List<Tab> tabList = plan.getTabs();
+
+        List<Long> tabOrder = orderByNext(tabList);
+
+        List<TabOfPlanResponse> tabs = tabList.parallelStream().map(tab -> {
+            List<Task> tasksOfTab = tab.getTasks();
+            List<Long> taskOrder = orderByNext(tasksOfTab);
+            return new TabOfPlanResponse().toPlanResponse(tab, taskOrder);
+        }).toList();
+
+        List<LabelOfPlanResponse> labels =
+            plan.getLabels().stream().map(label -> new LabelOfPlanResponse().toPlanResponse(label)
+            ).toList();
+
+        List<TaskOfPlanResponse> tasks =
+            plan.getTasks().stream().map(task -> new TaskOfPlanResponse().toPlanResponse(task)
+            ).toList();
+
+        return PlanResponse.builder()
+            .title(plan.getTitle())
+            .description(plan.getIntro())
+            .members(members)
+            .tabOrder(tabOrder)
+            .tabs(tabs)
+            .tasks(tasks)
+            .labels(labels)
+            .isPublic(plan.isPublic())
+            .build();
+    }
+
     private void sendInviteMail(List<String> invitedEmails, String title) {
         invitedEmails.forEach(email -> emailService.sendEmail(email, title));
     }
@@ -55,6 +103,31 @@ public class PlanService {
         firstTab.connect(lastTab);
         tabRepository.save(firstTab);
         tabRepository.save(lastTab);
+    }
+
+    @Transactional
+    public <T extends Linkable<T>> List<Long> orderByNext(List<T> items) {
+        List<Long> orderedItems = new ArrayList<>();
+        Hibernate.initialize(items);
+        Set<T> allNodes = new HashSet<>(items);
+
+        T start = null;
+        for (T item : items) {
+            if (item.getNext() != null) {
+                allNodes.remove(item.getNext());
+            }
+        }
+        if (!allNodes.isEmpty()) {
+            start = allNodes.iterator().next();
+        }
+
+        T current = start;
+        while (current != null) {
+            orderedItems.add(current.getId());
+            current = current.getNext();
+        }
+
+        return orderedItems;
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -36,6 +36,8 @@ public class TabService {
             List<Tab> tabsOfPlan = tabRepository.findAllByPlanId(plan.getId());
             TabGroup tabGroup = new TabGroup(plan.getId(), tabsOfPlan);
             tabGroup.addLast(createdTab);
+            plan.getTabs().add(createdTab);
+
             Tab savedTab = tabRepository.save(createdTab);
             return savedTab.getId();
         } catch (ObjectOptimisticLockingFailureException e) {

--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -47,8 +47,6 @@ public class TaskService {
                 .build();
             tab.changeLastTask(task);
             Task savedTask = taskRepository.save(task);
-            tab.getPlan().getTasks().add(task);
-            tab.getTasks().add(task);
             saveAllLabelOfTask(request.getLabels(), task, tab.getPlan());
             return savedTask.getId();
         } catch (ObjectOptimisticLockingFailureException e) {

--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -47,6 +47,8 @@ public class TaskService {
                 .build();
             tab.changeLastTask(task);
             Task savedTask = taskRepository.save(task);
+            tab.getPlan().getTasks().add(task);
+            tab.getTasks().add(task);
             saveAllLabelOfTask(request.getLabels(), task, tab.getPlan());
             return savedTask.getId();
         } catch (ObjectOptimisticLockingFailureException e) {

--- a/plan-service/src/main/java/com/example/planservice/domain/Linkable.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/Linkable.java
@@ -1,0 +1,7 @@
+package com.example.planservice.domain;
+
+public interface Linkable<T> {
+    T getNext();
+
+    Long getId();
+}

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -9,6 +9,10 @@ import org.hibernate.annotations.Where;
 import com.example.planservice.domain.BaseEntity;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.member.Member;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.task.Task;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,6 +43,18 @@ public class Plan extends BaseEntity {
     @JoinColumn(name = "owner_id")
     private Member owner;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    private List<Label> labels = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    private List<MemberOfPlan> members = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Task> tasks;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    private List<Tab> tabs = new ArrayList<>();
+
     private String title;
 
     private String intro;
@@ -51,8 +67,6 @@ public class Plan extends BaseEntity {
 
     private boolean isDeleted;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
-    private List<Label> labels = new ArrayList<>();
 
     @Builder
     private Plan(Member owner, String title, String intro, boolean isPublic, int starCnt, int viewCnt,
@@ -71,7 +85,7 @@ public class Plan extends BaseEntity {
             .anyMatch(label -> Objects.equals(label.getName(), name));
     }
 
-    public void remove(Label label) {
+    public void removeLabel(Label label) {
         labels.remove(label);
     }
 

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -50,7 +50,7 @@ public class Plan extends BaseEntity {
     private List<MemberOfPlan> members = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Task> tasks;
+    private List<Task> tasks = new ArrayList<>();
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
     private List<Tab> tabs = new ArrayList<>();
@@ -66,7 +66,6 @@ public class Plan extends BaseEntity {
     private int viewCnt;
 
     private boolean isDeleted;
-
 
     @Builder
     private Plan(Member owner, String title, String intro, boolean isPublic, int starCnt, int viewCnt,

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -47,7 +47,7 @@ public class Tab extends BaseEntity implements Linkable<Tab> {
 
     private String name;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "tab")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "tab")
     private List<Task> tasks = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -30,8 +30,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "tabs", uniqueConstraints = @UniqueConstraint(name = "UniquePlanAndTabName", columnNames = {"plan_id",
-    "name"}))
+@Table(name = "tabs",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "UniquePlanAndTabName", columnNames = {"plan_id", "name"})
+    })
 @Where(clause = "is_deleted = false")
 public class Tab extends BaseEntity implements Linkable<Tab> {
     public static final int TAB_MAX_SIZE = 5;
@@ -77,7 +79,7 @@ public class Tab extends BaseEntity implements Linkable<Tab> {
     }
 
     public static Tab create(Plan plan, String name) {
-        return builder()
+        return Tab.builder()
             .plan(plan)
             .name(name)
             .first(false)
@@ -85,7 +87,7 @@ public class Tab extends BaseEntity implements Linkable<Tab> {
     }
 
     public static Tab createTodoTab(Plan plan) {
-        return builder()
+        return Tab.builder()
             .plan(plan)
             .name("TODO")
             .first(true)

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -1,10 +1,13 @@
 package com.example.planservice.domain.task;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.annotations.Where;
 
 import com.example.planservice.domain.BaseEntity;
+import com.example.planservice.domain.Linkable;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.tab.Tab;
 import jakarta.persistence.Column;
@@ -15,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.AccessLevel;
@@ -28,7 +32,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "is_deleted = false")
 @Getter
-public class Task extends BaseEntity {
+public class Task extends BaseEntity implements Linkable<Task> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "task_id")
@@ -45,6 +49,9 @@ public class Task extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "task")
+    private List<LabelOfTask> labelOfTasks = new ArrayList<>();
 
     private String name;
 
@@ -96,7 +103,7 @@ public class Task extends BaseEntity {
     }
 
     public void delete() {
-        this.isDeleted = true;
+        isDeleted = true;
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -4,7 +4,10 @@ import java.net.URI;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.PlanService;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
-
+import com.example.planservice.presentation.dto.response.PlanResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -30,5 +33,10 @@ public class PlanController {
         }
         Long createdId = planService.create(request, userId);
         return ResponseEntity.created(URI.create("/plans/" + createdId)).build();
+    }
+
+    @GetMapping("/{planId}")
+    public ResponseEntity<PlanResponse> read(@PathVariable Long planId, @RequestAttribute Long userId) {
+        return ResponseEntity.ok(planService.getTotalPlanResponse(planId));
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -39,4 +40,11 @@ public class PlanController {
     public ResponseEntity<PlanResponse> read(@PathVariable Long planId, @RequestAttribute Long userId) {
         return ResponseEntity.ok(planService.getTotalPlanResponse(planId));
     }
+
+    @PutMapping("/invite/{planId}")
+    public ResponseEntity<Long> invite(@PathVariable Long planId, @RequestAttribute Long userId) {
+        Long memberOfPlanId = planService.inviteMember(planId, userId);
+        return ResponseEntity.ok(memberOfPlanId);
+    }
+
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
@@ -17,7 +17,7 @@ public class LabelOfPlanResponse {
         this.value = value;
     }
 
-    public static LabelOfPlanResponse toPlanResponse(Label label) {
+    public static LabelOfPlanResponse to(Label label) {
         return builder()
             .id(label.getId())
             .value(label.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
@@ -17,7 +17,7 @@ public class LabelOfPlanResponse {
         this.value = value;
     }
 
-    public LabelOfPlanResponse toPlanResponse(Label label) {
+    public static LabelOfPlanResponse toPlanResponse(Label label) {
         return builder()
             .id(label.getId())
             .value(label.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
@@ -1,0 +1,26 @@
+package com.example.planservice.presentation.dto.response;
+
+import com.example.planservice.domain.label.Label;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LabelOfPlanResponse {
+    private Long id;
+    private String value;
+
+    @Builder
+    private LabelOfPlanResponse(Long id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public LabelOfPlanResponse toPlanResponse(Label label) {
+        return builder()
+            .id(label.getId())
+            .value(label.getName())
+            .build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
@@ -23,7 +23,7 @@ public class MemberOfPlanResponse {
         this.isAdmin = isAdmin;
     }
 
-    public static MemberOfPlanResponse toPlanResponse(Member member, Long planAdminId) {
+    public static MemberOfPlanResponse to(Member member, Long planAdminId) {
         return builder()
             .id(member.getId())
             .name(member.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
@@ -1,0 +1,35 @@
+package com.example.planservice.presentation.dto.response;
+
+import com.example.planservice.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberOfPlanResponse {
+    private Long id;
+    private String name;
+    private String imgSrc;  // 이미지 경로를 나타내는 필드로 추정
+    private boolean isAdmin;
+    private String mail;
+
+    @Builder
+    private MemberOfPlanResponse(Long id, String name, String imgSrc, String mail, boolean isAdmin) {
+        this.id = id;
+        this.name = name;
+        this.mail = mail;
+        this.imgSrc = imgSrc;
+        this.isAdmin = isAdmin;
+    }
+
+    public MemberOfPlanResponse toPlanResponse(Member member, Long planAdminId) {
+        return builder()
+            .id(member.getId())
+            .name(member.getName())
+            .mail(member.getEmail())
+            .imgSrc(member.getProfileUri())
+            .isAdmin(member.getId().equals(planAdminId))
+            .build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
@@ -23,13 +23,14 @@ public class MemberOfPlanResponse {
         this.isAdmin = isAdmin;
     }
 
-    public MemberOfPlanResponse toPlanResponse(Member member, Long planAdminId) {
+    public static MemberOfPlanResponse toPlanResponse(Member member, Long planAdminId) {
         return builder()
             .id(member.getId())
             .name(member.getName())
             .mail(member.getEmail())
             .imgSrc(member.getProfileUri())
-            .isAdmin(member.getId().equals(planAdminId))
+            .isAdmin(member.getId()
+                .equals(planAdminId))
             .build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanResponse.java
@@ -1,0 +1,36 @@
+package com.example.planservice.presentation.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class PlanResponse {
+    private String title;
+    private String description;
+    private List<MemberOfPlanResponse> members;
+    private List<Long> tabOrder;
+    private List<TabOfPlanResponse> tabs;
+    private List<TaskOfPlanResponse> tasks;
+    private List<LabelOfPlanResponse> labels;
+    private boolean isPublic;
+
+    @Builder
+    private PlanResponse(String title, String description, List<MemberOfPlanResponse> members, List<Long> tabOrder,
+                         List<TabOfPlanResponse> tabs, List<TaskOfPlanResponse> tasks, List<LabelOfPlanResponse> labels,
+                         boolean isPublic) {
+        this.title = title;
+        this.description = description;
+        this.members = members;
+        this.tabOrder = tabOrder;
+        this.tabs = tabs;
+        this.tasks = tasks;
+        this.labels = labels;
+        this.isPublic = isPublic;
+    }
+
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
@@ -21,7 +21,7 @@ public class TabOfPlanResponse {
         this.taskOrder = taskOrder;
     }
 
-    public TabOfPlanResponse toPlanResponse(Tab tab, List<Long> taskOrder) {
+    public static TabOfPlanResponse toPlanResponse(Tab tab, List<Long> taskOrder) {
         return builder()
             .id(tab.getId())
             .title(tab.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
@@ -1,0 +1,31 @@
+package com.example.planservice.presentation.dto.response;
+
+import java.util.List;
+
+import com.example.planservice.domain.tab.Tab;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TabOfPlanResponse {
+    private Long id;
+    private String title;
+    private List<Long> taskOrder;
+
+    @Builder
+    private TabOfPlanResponse(Long id, String title, List<Long> taskOrder) {
+        this.id = id;
+        this.title = title;
+        this.taskOrder = taskOrder;
+    }
+
+    public TabOfPlanResponse toPlanResponse(Tab tab, List<Long> taskOrder) {
+        return builder()
+            .id(tab.getId())
+            .title(tab.getName())
+            .taskOrder(taskOrder)
+            .build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
@@ -21,7 +21,7 @@ public class TabOfPlanResponse {
         this.taskOrder = taskOrder;
     }
 
-    public static TabOfPlanResponse toPlanResponse(Tab tab, List<Long> taskOrder) {
+    public static TabOfPlanResponse to(Tab tab, List<Long> taskOrder) {
         return builder()
             .id(tab.getId())
             .title(tab.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -31,7 +31,7 @@ public class TaskOfPlanResponse {
         this.endDate = endDate;
     }
 
-    public static TaskOfPlanResponse toPlanResponse(Task task) {
+    public static TaskOfPlanResponse to(Task task) {
         return builder()
             .id(task.getId())
             .title(task.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -1,0 +1,45 @@
+package com.example.planservice.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.example.planservice.domain.task.Task;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TaskOfPlanResponse {
+    private Long id;
+    private String title;
+    private List<Long> labels;
+    private Long tabId;
+    private Long assigneeId;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    @Builder
+    private TaskOfPlanResponse(Long id, String title, Long tabId, List<Long> labels, Long assigneeId,
+                               LocalDateTime startDate, LocalDateTime endDate) {
+        this.id = id;
+        this.title = title;
+        this.labels = labels;
+        this.tabId = tabId;
+        this.assigneeId = assigneeId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public TaskOfPlanResponse toPlanResponse(Task task) {
+        return builder()
+            .id(task.getId())
+            .title(task.getName())
+            .labels(task.getLabelOfTasks().stream().map(labelOfTask -> labelOfTask.getLabel().getId()).toList())
+            .tabId(task.getTab().getId())
+            .assigneeId(task.getWriter().getId())
+            .startDate(task.getStartDate())
+            .endDate(task.getEndDate())
+            .build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -35,11 +35,13 @@ public class TaskOfPlanResponse {
         return builder()
             .id(task.getId())
             .title(task.getName())
-            .labels(task.getLabelOfTasks().stream().map(labelOfTask -> labelOfTask.getLabel().getId()).toList())
+            .labels(task.getLabelOfTasks() != null ?
+                task.getLabelOfTasks().stream().map(labelOfTask -> labelOfTask.getLabel().getId()).toList() :
+                null)
             .tabId(task.getTab().getId())
-            .assigneeId(task.getWriter().getId())
-            .startDate(task.getStartDate())
-            .endDate(task.getEndDate())
+            .assigneeId(task.getWriter() != null ? task.getWriter().getId() : null)
+            .startDate(task.getStartDate() != null ? task.getStartDate() : null)
+            .endDate(task.getEndDate() != null ? task.getEndDate() : null)
             .build();
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -31,15 +31,21 @@ public class TaskOfPlanResponse {
         this.endDate = endDate;
     }
 
-    public TaskOfPlanResponse toPlanResponse(Task task) {
+    public static TaskOfPlanResponse toPlanResponse(Task task) {
         return builder()
             .id(task.getId())
             .title(task.getName())
             .labels(task.getLabelOfTasks() != null ?
-                task.getLabelOfTasks().stream().map(labelOfTask -> labelOfTask.getLabel().getId()).toList() :
+                task.getLabelOfTasks()
+                    .stream()
+                    .map(labelOfTask -> labelOfTask.getLabel()
+                        .getId())
+                    .toList() :
                 null)
-            .tabId(task.getTab().getId())
-            .assigneeId(task.getWriter() != null ? task.getWriter().getId() : null)
+            .tabId(task.getTab()
+                .getId())
+            .assigneeId(task.getWriter() != null ? task.getWriter()
+                .getId() : null)
             .startDate(task.getStartDate() != null ? task.getStartDate() : null)
             .endDate(task.getEndDate() != null ? task.getEndDate() : null)
             .build();

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -2,7 +2,9 @@ package com.example.planservice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,13 +17,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.domain.label.Label;
+import com.example.planservice.domain.label.repository.LabelRepository;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
+import com.example.planservice.domain.memberofplan.MemberOfPlan;
+import com.example.planservice.domain.memberofplan.repository.MemberOfPlanRepository;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.tab.repository.TabRepository;
+import com.example.planservice.domain.task.Task;
+import com.example.planservice.domain.task.repository.TaskRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.response.PlanResponse;
 
 @SpringBootTest
 @Transactional
@@ -36,7 +47,19 @@ class PlanServiceTest {
     PlanRepository planRepository;
 
     @Autowired
+    TabRepository tabRepository;
+
+    @Autowired
     MemberRepository memberRepository;
+
+    @Autowired
+    LabelRepository labelRepository;
+
+    @Autowired
+    MemberOfPlanRepository memberOfPlanRepository;
+
+    @Autowired
+    TaskRepository taskRepository;
     private Long userId;
 
     @BeforeEach
@@ -94,5 +117,193 @@ class PlanServiceTest {
         assertThatThrownBy(() -> planService.create(request, notRegisteredUserId))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("플랜의 전체 정보를 가져온다")
+    void getTotalPlanResponse() {
+        // given
+        List<String> invitedEmails = List.of("test@example.com");
+        Member member1 = Member.builder()
+            .email("test1@example.com")
+            .name("test1")
+            .profileUri("www.test1")
+            .build();
+
+        Member member2 = Member.builder()
+            .email("test2@example.com")
+            .name("test2")
+            .profileUri("www.test2")
+            .build();
+
+        Plan plan = Plan.builder()
+            .owner(member1)
+            .title("testPlan")
+            .intro("hi")
+            .build();
+
+        Tab tab2 = Tab.builder()
+            .plan(plan)
+            .name("testTab2")
+            .tasks(new ArrayList<>())
+            .first(false)
+            .build();
+
+        Tab tab1 = Tab.builder()
+            .plan(plan)
+            .name("testTab1")
+            .next(tab2)
+            .tasks(new ArrayList<>())
+            .first(true)
+            .build();
+
+        Task task2 = Task.builder()
+            .name("testTask2")
+            .tab(tab1)
+            .description("testTaskDesc2")
+            .build();
+
+        Task task1 = Task.builder()
+            .name("testTask1")
+            .tab(tab1)
+            .description("testTaskDesc1")
+            .next(task2)
+            .build();
+
+        Task task3 = Task.builder()
+            .name("testTask3")
+            .tab(tab2)
+            .description("testTaskDesc3")
+            .build();
+
+        Label label1 = Label.builder()
+            .name("testLabel1")
+            .plan(plan)
+            .build();
+
+        Label label2 = Label.builder()
+            .name("testLabel2")
+            .plan(plan)
+            .build();
+
+        MemberOfPlan memberOfPlan1 = MemberOfPlan.builder().member(member1).plan(plan).build();
+        MemberOfPlan memberOfPlan2 = MemberOfPlan.builder().member(member2).plan(plan).build();
+        plan.getTabs().add(tab1);
+        plan.getTabs().add(tab2);
+
+        plan.getMembers().add(memberOfPlan1);
+        plan.getMembers().add(memberOfPlan2);
+
+        plan.getTasks().add(task1);
+        plan.getTasks().add(task2);
+        plan.getTasks().add(task3);
+
+        plan.getLabels().add(label1);
+        plan.getLabels().add(label2);
+
+        tab1.getTasks().add(task1);
+        tab1.getTasks().add(task2);
+        tab2.getTasks().add(task3);
+        memberRepository.saveAll(List.of(member1, member2));
+        planRepository.save(plan);
+        memberOfPlanRepository.saveAll(List.of(memberOfPlan1, memberOfPlan2));
+        tabRepository.saveAll(List.of(tab1, tab2));
+        taskRepository.saveAll(List.of(task1, task2, task3));
+
+        // when
+        PlanResponse planResponse = planService.getTotalPlanResponse(1L);
+
+        // then
+        assertThat(planResponse).isNotNull();
+        assertThat(planResponse.getTitle()).isEqualTo("testPlan");
+        assertThat(planResponse.getDescription()).isEqualTo("hi");
+        assertThat(planResponse.getTabOrder()).isEqualTo(List.of(tab1.getId(), tab2.getId()));
+        assertThat(planResponse.getMembers().get(0).getMail()).isEqualTo("test1@example.com");
+        assertThat(planResponse.getMembers().get(1).getMail()).isEqualTo("test2@example.com");
+        assertThat(planResponse.getTabs().get(0).getTitle()).isEqualTo("testTab1");
+        assertThat(planResponse.getTabs().get(1).getTitle()).isEqualTo("testTab2");
+        assertThat(planResponse.getTasks().get(0).getTitle()).isEqualTo("testTask1");
+        assertThat(planResponse.getTasks().get(1).getTitle()).isEqualTo("testTask2");
+        assertThat(planResponse.getTasks().get(2).getTitle()).isEqualTo("testTask3");
+        assertThat(planResponse.getLabels().get(0).getValue()).isEqualTo("testLabel1");
+        assertThat(planResponse.getLabels().get(1).getValue()).isEqualTo("testLabel2");
+        assertThat(planResponse.isPublic()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 전체 정보를 요청하면 PLAN_NOT_FOUND 예외를 발생시킨다")
+    void getTotalPlanResponse_withNonExistentPlanId_throwsException() {
+        // given
+        Long nonExistentPlanId = 9999L;
+
+        // when / then
+        assertThrows(ApiException.class, () -> planService.getTotalPlanResponse(nonExistentPlanId), "PLAN_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("멤버를 플랜에 초대한다")
+    void inviteMember() {
+        // given
+        Plan plan = Plan.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .build();
+        Plan savedPlan = planRepository.save(plan);
+
+        Member member = Member.builder()
+            .name("tester")
+            .email("test@example.com")
+            .build();
+        Member savedMember = memberRepository.save(member);
+
+        // when
+        Long memberOfPlanId = planService.inviteMember(savedPlan.getId(), savedMember.getId());
+
+        // then
+        assertThat(memberOfPlanId).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버로 초대를 시도하면 실패한다")
+    void inviteFailNotExistMember() {
+        // given
+        Long notRegisteredPlanId = 10L;
+
+        Plan plan = Plan.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .build();
+        Plan savedPlan = planRepository.save(plan);
+
+        Long notRegisteredMemberId = 20L;
+
+        // when & then
+        assertThatThrownBy(() -> planService.inviteMember(savedPlan.getId(), notRegisteredMemberId))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜으로 초대를 시도하면 실패한다")
+    void inviteFailNotExistPlan() {
+        // given
+        Long notRegisteredPlanId = 10L;
+
+        Member member = Member.builder()
+            .name("tester")
+            .email("test@example.com")
+            .build();
+        Member savedMember = memberRepository.save(member);
+
+        // when & then
+        assertThatThrownBy(() -> planService.inviteMember(notRegisteredPlanId, savedMember.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+
+
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -66,7 +66,7 @@ class PlanServiceTest {
     void testSetUp() {
         Member member = Member.builder()
             .name("tester")
-            .email("test@example.com")
+            .email("testEach@example.com")
             .build();
         Member savedMember = memberRepository.save(member);
         userId = savedMember.getId();
@@ -123,7 +123,6 @@ class PlanServiceTest {
     @DisplayName("플랜의 전체 정보를 가져온다")
     void getTotalPlanResponse() {
         // given
-        List<String> invitedEmails = List.of("test@example.com");
         Member member1 = Member.builder()
             .email("test1@example.com")
             .name("test1")
@@ -211,7 +210,7 @@ class PlanServiceTest {
         taskRepository.saveAll(List.of(task1, task2, task3));
 
         // when
-        PlanResponse planResponse = planService.getTotalPlanResponse(1L);
+        PlanResponse planResponse = planService.getTotalPlanResponse(plan.getId());
 
         // then
         assertThat(planResponse).isNotNull();
@@ -268,15 +267,12 @@ class PlanServiceTest {
     @DisplayName("존재하지 않는 멤버로 초대를 시도하면 실패한다")
     void inviteFailNotExistMember() {
         // given
-        Long notRegisteredPlanId = 10L;
-
         Plan plan = Plan.builder()
             .title("플랜 제목")
             .intro("플랜 소개")
             .isPublic(true)
             .build();
         Plan savedPlan = planRepository.save(plan);
-
         Long notRegisteredMemberId = 20L;
 
         // when & then

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -2,7 +2,6 @@ package com.example.planservice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,8 +70,10 @@ class PlanServiceTest {
         Member savedMember = memberRepository.save(member);
         userId = savedMember.getId();
 
-        Mockito.doNothing().when(emailService).sendEmail(ArgumentMatchers.anyString(),
-            ArgumentMatchers.anyString());
+        Mockito.doNothing()
+            .when(emailService)
+            .sendEmail(ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString());
     }
 
     @Test
@@ -94,7 +95,8 @@ class PlanServiceTest {
         // then
         assertThat(savedId).isNotNull();
 
-        Plan savedPlan = planRepository.findById(savedId).get();
+        Plan savedPlan = planRepository.findById(savedId)
+            .get();
         assertThat(savedPlan.getTitle()).isEqualTo(request.getTitle());
         assertThat(savedPlan.getIntro()).isEqualTo(request.getIntro());
     }
@@ -185,24 +187,42 @@ class PlanServiceTest {
             .plan(plan)
             .build();
 
-        MemberOfPlan memberOfPlan1 = MemberOfPlan.builder().member(member1).plan(plan).build();
-        MemberOfPlan memberOfPlan2 = MemberOfPlan.builder().member(member2).plan(plan).build();
-        plan.getTabs().add(tab1);
-        plan.getTabs().add(tab2);
+        MemberOfPlan memberOfPlan1 = MemberOfPlan.builder()
+            .member(member1)
+            .plan(plan)
+            .build();
+        MemberOfPlan memberOfPlan2 = MemberOfPlan.builder()
+            .member(member2)
+            .plan(plan)
+            .build();
+        plan.getTabs()
+            .add(tab1);
+        plan.getTabs()
+            .add(tab2);
 
-        plan.getMembers().add(memberOfPlan1);
-        plan.getMembers().add(memberOfPlan2);
+        plan.getMembers()
+            .add(memberOfPlan1);
+        plan.getMembers()
+            .add(memberOfPlan2);
 
-        plan.getTasks().add(task1);
-        plan.getTasks().add(task2);
-        plan.getTasks().add(task3);
+        plan.getTasks()
+            .add(task1);
+        plan.getTasks()
+            .add(task2);
+        plan.getTasks()
+            .add(task3);
 
-        plan.getLabels().add(label1);
-        plan.getLabels().add(label2);
+        plan.getLabels()
+            .add(label1);
+        plan.getLabels()
+            .add(label2);
 
-        tab1.getTasks().add(task1);
-        tab1.getTasks().add(task2);
-        tab2.getTasks().add(task3);
+        tab1.getTasks()
+            .add(task1);
+        tab1.getTasks()
+            .add(task2);
+        tab2.getTasks()
+            .add(task3);
         memberRepository.saveAll(List.of(member1, member2));
         planRepository.save(plan);
         memberOfPlanRepository.saveAll(List.of(memberOfPlan1, memberOfPlan2));
@@ -217,15 +237,33 @@ class PlanServiceTest {
         assertThat(planResponse.getTitle()).isEqualTo("testPlan");
         assertThat(planResponse.getDescription()).isEqualTo("hi");
         assertThat(planResponse.getTabOrder()).isEqualTo(List.of(tab1.getId(), tab2.getId()));
-        assertThat(planResponse.getMembers().get(0).getMail()).isEqualTo("test1@example.com");
-        assertThat(planResponse.getMembers().get(1).getMail()).isEqualTo("test2@example.com");
-        assertThat(planResponse.getTabs().get(0).getTitle()).isEqualTo("testTab1");
-        assertThat(planResponse.getTabs().get(1).getTitle()).isEqualTo("testTab2");
-        assertThat(planResponse.getTasks().get(0).getTitle()).isEqualTo("testTask1");
-        assertThat(planResponse.getTasks().get(1).getTitle()).isEqualTo("testTask2");
-        assertThat(planResponse.getTasks().get(2).getTitle()).isEqualTo("testTask3");
-        assertThat(planResponse.getLabels().get(0).getValue()).isEqualTo("testLabel1");
-        assertThat(planResponse.getLabels().get(1).getValue()).isEqualTo("testLabel2");
+        assertThat(planResponse.getMembers()
+            .get(0)
+            .getMail()).isEqualTo("test1@example.com");
+        assertThat(planResponse.getMembers()
+            .get(1)
+            .getMail()).isEqualTo("test2@example.com");
+        assertThat(planResponse.getTabs()
+            .get(0)
+            .getTitle()).isEqualTo("testTab1");
+        assertThat(planResponse.getTabs()
+            .get(1)
+            .getTitle()).isEqualTo("testTab2");
+        assertThat(planResponse.getTasks()
+            .get(0)
+            .getTitle()).isEqualTo("testTask1");
+        assertThat(planResponse.getTasks()
+            .get(1)
+            .getTitle()).isEqualTo("testTask2");
+        assertThat(planResponse.getTasks()
+            .get(2)
+            .getTitle()).isEqualTo("testTask3");
+        assertThat(planResponse.getLabels()
+            .get(0)
+            .getValue()).isEqualTo("testLabel1");
+        assertThat(planResponse.getLabels()
+            .get(1)
+            .getValue()).isEqualTo("testLabel2");
         assertThat(planResponse.isPublic()).isFalse();
     }
 
@@ -236,7 +274,9 @@ class PlanServiceTest {
         Long nonExistentPlanId = 9999L;
 
         // when / then
-        assertThrows(ApiException.class, () -> planService.getTotalPlanResponse(nonExistentPlanId), "PLAN_NOT_FOUND");
+        assertThatThrownBy(() -> planService.getTotalPlanResponse(nonExistentPlanId))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -248,16 +288,16 @@ class PlanServiceTest {
             .intro("플랜 소개")
             .isPublic(true)
             .build();
-        Plan savedPlan = planRepository.save(plan);
+        planRepository.save(plan);
 
         Member member = Member.builder()
             .name("tester")
             .email("test@example.com")
             .build();
-        Member savedMember = memberRepository.save(member);
+        memberRepository.save(member);
 
         // when
-        Long memberOfPlanId = planService.inviteMember(savedPlan.getId(), savedMember.getId());
+        Long memberOfPlanId = planService.inviteMember(plan.getId(), member.getId());
 
         // then
         assertThat(memberOfPlanId).isNotNull();

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -1,8 +1,14 @@
 package com.example.planservice.presentation;
 
-import com.example.planservice.application.PlanService;
-import com.example.planservice.presentation.dto.request.PlanCreateRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,14 +17,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.example.planservice.application.PlanService;
+import com.example.planservice.exception.ApiException;
+import com.example.planservice.exception.ErrorCode;
+import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.response.PlanResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(PlanController.class)
 class PlanControllerTest {
@@ -36,23 +40,23 @@ class PlanControllerTest {
         Long userId = 1L;
         List<String> invitedEmails = List.of("test@example.com");
         PlanCreateRequest request = PlanCreateRequest.builder()
-                .title("플랜 제목")
-                .intro("플랜 소개")
-                .isPublic(true)
-                .invitedEmails(invitedEmails)
-                .build();
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .invitedEmails(invitedEmails)
+            .build();
 
         when(planService.create(any(PlanCreateRequest.class), anyLong()))
-                .thenReturn(1L);
+            .thenReturn(1L);
 
         // when & then
         mockMvc.perform(post("/plans")
-                        .header("X-User-Id", userId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(header().exists("Location"))
-                .andExpect(redirectedUrlPattern("/plans/*"));
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(header().exists("Location"))
+            .andExpect(redirectedUrlPattern("/plans/*"));
     }
 
     @Test
@@ -64,17 +68,17 @@ class PlanControllerTest {
         invitedEmails.add("B@gmail.com");
 
         PlanCreateRequest request = PlanCreateRequest.builder()
-                .title("플랜 제목")
-                .intro("플랜 소개")
-                .isPublic(true)
-                .invitedEmails(invitedEmails)
-                .build();
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .invitedEmails(invitedEmails)
+            .build();
 
         // when & then
         mockMvc.perform(post("/plans")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isUnauthorized());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -85,17 +89,91 @@ class PlanControllerTest {
         List<String> invalidEmails = List.of("invalid-email");
 
         PlanCreateRequest request = PlanCreateRequest.builder()
-                .title("플랜 제목")
-                .intro("플랜 소개")
-                .isPublic(true)
-                .invitedEmails(invalidEmails)
-                .build();
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .invitedEmails(invalidEmails)
+            .build();
 
         // when & then
         mockMvc.perform(post("/plans")
-                        .header("X-User-Id", userId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @DisplayName("플랜 정보를 조회한다")
+    void readPlan() throws Exception {
+        // given
+        Long userId = 1L;
+        Long planId = 1L;
+
+        PlanResponse planResponse = PlanResponse.builder()
+            .title("플랜 제목")
+            .description("플랜 소개")
+            .isPublic(true)
+            .build();
+
+        when(planService.getTotalPlanResponse(planId)).thenReturn(planResponse);
+
+        // when & then
+        mockMvc.perform(get("/plans/{planId}", planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.title").value(planResponse.getTitle()))
+            .andExpect(jsonPath("$.description").value(planResponse.getDescription()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 정보를 조회하면 실패한다")
+    void readPlanFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long invalidPlanId = 9999L;
+
+        when(planService.getTotalPlanResponse(invalidPlanId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/plans/{planId}", invalidPlanId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("사용자를 플랜에 초대한다")
+    void inviteMember() throws Exception {
+        // given
+        Long userId = 1L;
+        Long planId = 1L;
+
+        when(planService.inviteMember(planId, userId)).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(put("/invite/{planId}", planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string("1"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 사용자를 초대하면 실패한다")
+    void inviteMemberFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long invalidPlanId = 9999L;
+
+        when(planService.inviteMember(invalidPlanId, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(put("/invite/{planId}", invalidPlanId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -153,7 +153,7 @@ class PlanControllerTest {
         when(planService.inviteMember(planId, userId)).thenReturn(1L);
 
         // when & then
-        mockMvc.perform(put("/invite/{planId}", planId)
+        mockMvc.perform(put("/plans/invite/{planId}", planId)
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())


### PR DESCRIPTION
📌 Description
- 플랜 조회 기능을 추가했습니다. 
- 플랜 초대 기능을 추가했습니다.
- Plan엔티티 에서 Label, Tab, Task, Member와 OneToMany관계를 맺어주었습니다.
- Tab 엔티티에서 Task와 OneToMany관계를 맺어주었습니다.
- TabOrder와 TaskOrder의 순서를 배열로 정리하기위해  Linkable이란 인터페이스를 Tab과 Task에 implements하였습니다. 그냥 Tab과 Task 각각 Order를 정리하는 로직을 작성하는게 나을까요?
- tab.getTasks()를 Lazy방식으로 했을때 느리게 받아와 null 이되는경우가 있어 fetch방식을 Eager로 해주었습니다. 성능상 문제가 생길것도 같은데 혹시 어떻게 생각하시는지 궁금합니다. 


⚠️ 주의사항
- 

close #34 
close #72 