### PR TITLE
[#80] 멤버 단건 조회 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/MemberService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/MemberService.java
@@ -1,5 +1,7 @@
 package com.example.planservice.application;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,9 +11,8 @@ import com.example.planservice.domain.member.repository.MemberRepository;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.MemberRegisterRequest;
+import com.example.planservice.presentation.dto.response.MemberFindResponse;
 import lombok.RequiredArgsConstructor;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +30,14 @@ public class MemberService {
         Member member = request.toEntity();
         memberRepository.save(member);
         return MemberRegisterResponse.of(member);
+    }
+
+    public MemberFindResponse find(Long id) {
+        Member member = memberRepository.findById(id)
+            .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+        if (!member.isNormalUser()) {
+            throw new ApiException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+        return MemberFindResponse.from(member);
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
+++ b/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
@@ -1,6 +1,9 @@
 package com.example.planservice.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -8,10 +11,14 @@ import com.example.planservice.interceptor.AuthenticationInterceptor;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Bean
+    public PathMatcher pathMatcher() {
+        return new AntPathMatcher();
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthenticationInterceptor());
+        registry.addInterceptor(new AuthenticationInterceptor(pathMatcher()));
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/member/Member.java
@@ -61,4 +61,8 @@ public class Member extends BaseEntity {
         this.role = Role.USER;
         this.isDeleted = false;
     }
+
+    public boolean isNormalUser() {
+        return role == Role.USER;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
+++ b/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
@@ -20,8 +20,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private static List<WhiteListEntry> getWhiteList() {
         return List.of(
-            new WhiteListEntry(HttpMethod.POST, "/members"),
-            new WhiteListEntry(HttpMethod.GET, "/members/{id}"));
+            new WhiteListEntry(HttpMethod.POST, "/members")
+        );
     }
 
     @Override

--- a/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
+++ b/plan-service/src/main/java/com/example/planservice/interceptor/AuthenticationInterceptor.java
@@ -3,6 +3,7 @@ package com.example.planservice.interceptor;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.util.PathMatcher;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import io.netty.handler.codec.http.HttpMethod;
@@ -11,13 +12,22 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
-    private static final List<WhiteListEntry> whiteList = List.of(new WhiteListEntry(HttpMethod.POST, "/members"));
+    private static final List<WhiteListEntry> whiteList = getWhiteList();
+
+    private final PathMatcher pathMatcher;
+
+    private static List<WhiteListEntry> getWhiteList() {
+        return List.of(
+            new WhiteListEntry(HttpMethod.POST, "/members"),
+            new WhiteListEntry(HttpMethod.GET, "/members/{id}"));
+    }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         boolean isInWhiteList = whiteList.stream()
-            .anyMatch(each -> each.match(request));
+            .anyMatch(each -> each.match(request, pathMatcher));
         if (isInWhiteList) {
             return true;
         }
@@ -42,12 +52,12 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @AllArgsConstructor
     static class WhiteListEntry {
         HttpMethod httpMethod;
-        String uri;
+        String uriPattern;
 
-        public boolean match(HttpServletRequest request) {
+        public boolean match(HttpServletRequest request, PathMatcher pathMatcher) {
             String requestUri = request.getRequestURI();
             String method = request.getMethod();
-            return httpMethod.toString().equals(method) && uri.equals(requestUri);
+            return httpMethod.toString().equals(method) && pathMatcher.match(uriPattern, requestUri);
         }
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/MemberController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/MemberController.java
@@ -3,6 +3,8 @@ package com.example.planservice.presentation;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.planservice.application.MemberService;
 import com.example.planservice.application.dto.MemberRegisterResponse;
 import com.example.planservice.presentation.dto.request.MemberRegisterRequest;
+import com.example.planservice.presentation.dto.response.MemberFindResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -26,4 +29,8 @@ public class MemberController {
         return ResponseEntity.created(URI.create("/members/" + response.getId())).body(response);
     }
 
+    @GetMapping("/{id}")
+    ResponseEntity<MemberFindResponse> find(@PathVariable Long id) {
+        return ResponseEntity.ok(memberService.find(id));
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberFindResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberFindResponse.java
@@ -1,0 +1,32 @@
+package com.example.planservice.presentation.dto.response;
+
+import com.example.planservice.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberFindResponse {
+    private Long id;
+    private String name;
+    private String email;
+    private String profileUri;
+
+    @Builder
+    private MemberFindResponse(Long id, String name, String email, String profileUri) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.profileUri = profileUri;
+    }
+
+    public static MemberFindResponse from(Member member) {
+        return MemberFindResponse.builder()
+            .id(member.getId())
+            .name(member.getName())
+            .email(member.getEmail())
+            .profileUri(member.getProfileUri())
+            .build();
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
+++ b/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
@@ -8,9 +8,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 
 @SpringBootTest
 class AuthenticationInterceptorTest {
@@ -18,9 +22,12 @@ class AuthenticationInterceptorTest {
     MockHttpServletRequest request;
     MockHttpServletResponse response;
 
+    @Autowired
+    PathMatcher pathMatcher;
+
     @BeforeEach
     void setup() {
-        interceptor = new AuthenticationInterceptor();
+        interceptor = new AuthenticationInterceptor(pathMatcher);
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
     }

--- a/plan-service/src/test/java/com/example/planservice/presentation/MemberControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/MemberControllerTest.java
@@ -108,11 +108,23 @@ class MemberControllerTest {
             .thenReturn(response);
 
         // when & then
-        mockMvc.perform(get("/members/" + targetMemberId))
+        mockMvc.perform(get("/members/" + targetMemberId)
+                .header("X-User-Id", 1L))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(response.getId()))
             .andExpect(jsonPath("$.name").value(response.getName()))
             .andExpect(jsonPath("$.email").value(response.getEmail()))
             .andExpect(jsonPath("$.profileUri").value(response.getProfileUri()));
+    }
+
+    @Test
+    @DisplayName("로그인한 유저만 Member를 조회할 수 있다")
+    void testFindMemberFailNotLogin() throws Exception {
+        // given
+        Long targetMemberId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/members/" + targetMemberId))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/MemberControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.example.planservice.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -16,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.example.planservice.application.MemberService;
 import com.example.planservice.application.dto.MemberRegisterResponse;
 import com.example.planservice.presentation.dto.request.MemberRegisterRequest;
+import com.example.planservice.presentation.dto.response.MemberFindResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = MemberController.class)
@@ -87,5 +89,30 @@ class MemberControllerTest {
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", "/members/" + response.getId()))
             .andExpect(jsonPath("$.id").value(response.getId()));
+    }
+
+    @Test
+    @DisplayName("Member를 조회한다")
+    void testFindMember() throws Exception {
+        // given
+        Long targetMemberId = 1L;
+        MemberFindResponse response = MemberFindResponse.builder()
+            .id(targetMemberId)
+            .name("김태훈")
+            .email("ds@naver.com")
+            .profileUri("https://sda.com")
+            .build();
+
+        // stub
+        when(memberService.find(targetMemberId))
+            .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/members/" + targetMemberId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(response.getId()))
+            .andExpect(jsonPath("$.name").value(response.getName()))
+            .andExpect(jsonPath("$.email").value(response.getEmail()))
+            .andExpect(jsonPath("$.profileUri").value(response.getProfileUri()));
     }
 }


### PR DESCRIPTION
## 📌 Description
멤버 단건 조회 기능을 구현했습니다.
로그인한 사용자만 접근 가능하도록 구현했습니다.
그리고 Admin 사용자는 조회가 안되도록 만들어주었습니다.

## ⚠️ 주의사항
AuthenticationInterceptor 내부 로직이 변경되었습니다.
과거에는 URI에 변수가 있는 GET /members/{id} 와 같은 로직을 처리할 수 없었습니다.
해당 부분을 처리할 수 있도록 PathMatcher를 주입해서 사용하는 방식으로 변경했습니다.

close #80 
