### PR TITLE
[#82] docker-compose 오류해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,4 +62,4 @@ services:
     ports:
       - ${MYSQL_PORT}:${MYSQL_PORT}
     volumes:
-      - ./initdb.sql:/docker-entrypoint-initdb.d/initdb.sql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
       - ${MYSQL_PORT}:${MYSQL_PORT}
+    volumes:
+      - ./initdb.sql:/docker-entrypoint-initdb.d/initdb.sql

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE plan_db;
+CREATE DATABASE auth_db;

--- a/initdb.sql
+++ b/initdb.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE plandb;
+CREATE DATABASE authdb;

--- a/initdb.sql
+++ b/initdb.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE plandb;
-CREATE DATABASE authdb;


### PR DESCRIPTION


## 📌 Description
- Environment 파일 오타 수정
- mysql 컨테이너에서 하나의 db 에 auth-service연결후 plan-service가 create-drop 을 하려고할때 에러가 발생했습니다.  이를 해결하기위해 docker-compose build 과정에서 db를 두개 생성하기위해 initdb.sql을 추가하였습니다.
## ⚠️ 주의사항
- 
close #82 
