### PR TITLE
[#29, #30, #33, #86, #87, #88] 플랜 설정, 나가기, 추방, 멤버id 조회 구현 및 리팩토링

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/EmailService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/EmailService.java
@@ -30,7 +30,7 @@ public class EmailService {
         session = createSession();
     }
 
-    public void sendEmail(String to, String text) {
+    public void sendInviteEmail(String to, String text, Long userId) {
         try {
             Message message = new MimeMessage(session);
             message.setFrom(new InternetAddress(mailProperties.getUsername()));
@@ -38,7 +38,7 @@ public class EmailService {
             message.setSubject(INVITING_SUBJECT);
             String content = text + ' ' + INVITING_ANNOUNCEMENT;
             content += "<br>";
-            content += "http://localhost/invite";
+            content += "http://localhost/invite" + userId;
 
             message.setContent(content, "text/html; charset=utf-8");
 

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -123,17 +123,7 @@ public class PlanService {
             .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         validateOwner(plan.getOwner()
             .getId(), userId);
-        List<Long> kickingMemberIds = request.getKickingEmails()
-            .stream()
-            .map(email -> {
-                Member member = memberRepository.findByEmail(email)
-                    .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
-                return member.getId();
-            })
-            .toList();
-
-        memberOfPlanRepository.deleteAllByPlanIdAndMemberIds(planId, kickingMemberIds);
-
+        memberOfPlanRepository.deleteAllByPlanIdAndMemberIds(planId, request.getKickingMemberIds());
     }
 
     @Transactional
@@ -146,6 +136,7 @@ public class PlanService {
 
         Plan plan = memberOfPlan.getPlan();
         plan.softDelete();
+        planRepository.save(plan);
         memberOfPlanRepository.delete(memberOfPlan);
     }
 
@@ -170,8 +161,7 @@ public class PlanService {
     }
 
     private void validateOwner(Long ownerId, Long userId) {
-        if (!ownerId
-            .equals(userId)) {
+        if (!ownerId.equals(userId)) {
             throw new ApiException(ErrorCode.AUTHORIZATION_FAIL);
         }
     }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -150,6 +150,15 @@ public class PlanService {
         return plan.getId();
     }
 
+    public List<PlanTitleIdResponse> getAllPlanByMemberId(Long userId) {
+        List<MemberOfPlan> memberOfPlans = memberOfPlanRepository.findAllByMemberId(userId)
+            .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return memberOfPlans.stream()
+            .map(memberOfPlan -> PlanTitleIdResponse.from(memberOfPlan.getPlan()))
+            .toList();
+    }
+
     private void validateOwner(Long ownerId, Long userId) {
         if (!ownerId
             .equals(userId)) {

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -74,8 +74,12 @@ public class PlanService {
         List<Tab> tabList = tabRepository.findAllByPlanId(planId);
         List<MemberOfPlanResponse> members = getMemberResponses(plan.getMembers(), plan.getOwner()
             .getId());
+        List<Task> allTask = tabList.stream()
+            .map(Tab::getTasks)
+            .flatMap(List::stream)
+            .toList();
         List<LabelOfPlanResponse> labels = getLabelResponses(plan.getLabels());
-        List<TaskOfPlanResponse> tasks = getTaskResponses(plan.getTasks());
+        List<TaskOfPlanResponse> tasks = getTaskResponses(allTask);
         List<Long> tabOrder = getSortedTabID(tabList);
         List<TabOfPlanResponse> tabs = getTabResponses(tabList);
 
@@ -166,8 +170,8 @@ public class PlanService {
     }
 
     private void createDefaultTab(Plan plan) {
-        Tab todoTab = Tab.create(plan, "Todo");
-        Tab inprogressTab = Tab.create(plan, "In progress");
+        Tab todoTab = Tab.create(plan, "To Do");
+        Tab inprogressTab = Tab.create(plan, "In Progress");
         Tab doneTab = Tab.create(plan, "Done");
 
         todoTab.connect(inprogressTab);

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -108,25 +108,21 @@ public class PlanService {
     }
 
     @Transactional
-    public Long exit(Long planId, Long memberId) {
+    public void exit(Long planId, Long memberId) {
         memberOfPlanRepository.deleteByPlanIdAndMemberId(planId, memberId);
-        return memberId;
     }
 
     @Transactional
-    public Long kick(Long planId, Long kickingMemberId, Long userId) {
+    public void kick(Long planId, Long kickingMemberId, Long userId) {
         Plan plan = planRepository.findById(planId)
             .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         validateOwner(plan.getOwner()
             .getId(), userId);
-        MemberOfPlan memberOfPlan = memberOfPlanRepository.findByPlanIdAndMemberId(kickingMemberId, planId)
-            .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
-        memberOfPlanRepository.delete(memberOfPlan);
-        return memberOfPlan.getId();
+        memberOfPlanRepository.deleteByPlanIdAndMemberId(kickingMemberId, planId);
     }
 
     @Transactional
-    public Long delete(Long planId, Long userId) {
+    public void delete(Long planId, Long userId) {
         MemberOfPlan memberOfPlan = memberOfPlanRepository.findByPlanIdAndMemberId(planId, userId)
             .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND_IN_PLAN));
         validateOwner(memberOfPlan.getPlan()
@@ -135,11 +131,11 @@ public class PlanService {
 
         Plan plan = memberOfPlan.getPlan();
         plan.softDelete();
-        return plan.getId();
+        memberOfPlanRepository.delete(memberOfPlan);
     }
 
     @Transactional
-    public Long update(Long planId, PlanUpdateRequest request, Long userId) {
+    public void update(Long planId, PlanUpdateRequest request, Long userId) {
         Plan plan = planRepository.findById(planId)
             .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         validateOwner(plan.getOwner()
@@ -147,7 +143,6 @@ public class PlanService {
         Member nextOwner = memberRepository.findById(request.getOwnerId())
             .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
         plan.update(request.getTitle(), request.getIntro(), nextOwner, request.isPublic());
-        return plan.getId();
     }
 
     public List<PlanTitleIdResponse> getAllPlanByMemberId(Long userId) {
@@ -265,6 +260,5 @@ public class PlanService {
 
         return orderedItems;
     }
-
 
 }

--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -39,14 +39,11 @@ public class TabService {
             List<Tab> tabsOfPlan = tabRepository.findAllByPlanId(plan.getId());
             TabGroup tabGroup = new TabGroup(plan.getId(), tabsOfPlan);
             tabGroup.addLast(createdTab);
-            plan.getTabs().add(createdTab);
+            plan.getTabs()
+                .add(createdTab);
 
             Tab savedTab = tabRepository.save(createdTab);
-
-            List<Task> dummies = Task.createFirstAndLastDummy(createdTab);
-            Task firstDummyTask = dummies.get(0);
-            Task lastDummyTask = dummies.get(1);
-            taskRepository.saveAll(List.of(firstDummyTask, lastDummyTask));
+            createDummyTask(createdTab);
 
             return savedTab.getId();
         } catch (ObjectOptimisticLockingFailureException e) {
@@ -61,7 +58,9 @@ public class TabService {
         List<Tab> tabs = tabRepository.findAllByPlanId(request.getPlanId());
         TabGroup tabGroup = new TabGroup(plan.getId(), tabs);
         List<Tab> result = tabGroup.changeOrder(request.getTargetId(), request.getNewPrevId());
-        return result.stream().map(Tab::getId).toList();
+        return result.stream()
+            .map(Tab::getId)
+            .toList();
     }
 
     // TODO Tab은 Plan에 강하게 의존관계를 가짐. 단독으로 쓰일일도 잘 없음.(앞으로도 그럴거로 예상됨)
@@ -97,6 +96,13 @@ public class TabService {
         Tab target = tabGroup.findById(tabId);
         target.delete();
         return tabId;
+    }
+
+    public void createDummyTask(Tab createdTab) {
+        List<Task> dummies = Task.createFirstAndLastDummy(createdTab);
+        Task firstDummyTask = dummies.get(0);
+        Task lastDummyTask = dummies.get(1);
+        taskRepository.saveAll(List.of(firstDummyTask, lastDummyTask));
     }
 
     public TabFindResponse find(Long tabId, Long memberId) {

--- a/plan-service/src/main/java/com/example/planservice/domain/Linkable.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/Linkable.java
@@ -1,7 +1,0 @@
-package com.example.planservice.domain;
-
-public interface Linkable<T> {
-    T getNext();
-
-    Long getId();
-}

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -16,4 +19,9 @@ public interface MemberOfPlanRepository extends JpaRepository<MemberOfPlan, Long
 
     void deleteByPlanIdAndMemberId(Long planId, Long memberId);
 
+    @Modifying
+    @Query("DELETE FROM MemberOfPlan m WHERE m.plan.id = :planId AND m.member.id IN :memberIds")
+    void deleteAllByPlanIdAndMemberIds(@Param("planId") Long planId, @Param("memberIds") List<Long> memberIds);
+
+    Optional<List<MemberOfPlan>> findAllByPlanId(Long id);
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
@@ -1,14 +1,19 @@
 package com.example.planservice.domain.memberofplan.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
 
-import java.util.Optional;
-
 @Repository
 public interface MemberOfPlanRepository extends JpaRepository<MemberOfPlan, Long> {
     Optional<MemberOfPlan> findByPlanIdAndMemberId(Long planId, Long memberId);
+
+    Optional<List<MemberOfPlan>> findAllByMemberId(Long memberId);
+
+    void deleteByPlanIdAndMemberId(Long planId, Long memberId);
 
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -11,8 +11,6 @@ import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
 import com.example.planservice.domain.tab.Tab;
-import com.example.planservice.domain.task.Task;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -48,9 +46,6 @@ public class Plan extends BaseEntity {
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
     private List<MemberOfPlan> members = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Task> tasks = new ArrayList<>();
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
     private List<Tab> tabs = new ArrayList<>();

--- a/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/plan/Plan.java
@@ -91,4 +91,15 @@ public class Plan extends BaseEntity {
     public void addLabel(Label label) {
         labels.add(label);
     }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+    public void update(String title, String intro, Member owner, boolean isPublic) {
+        this.title = title;
+        this.intro = intro;
+        this.owner = owner;
+        this.isPublic = isPublic;
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -8,7 +8,6 @@ import org.hibernate.annotations.Where;
 import org.jetbrains.annotations.NotNull;
 
 import com.example.planservice.domain.BaseEntity;
-import com.example.planservice.domain.Linkable;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.task.Task;
 import jakarta.persistence.Column;
@@ -37,7 +36,7 @@ import lombok.NoArgsConstructor;
         @UniqueConstraint(name = "UniquePlanAndTabName", columnNames = {"plan_id", "name"})
     })
 @Where(clause = "is_deleted = false")
-public class Tab extends BaseEntity implements Linkable<Tab> {
+public class Tab extends BaseEntity {
     public static final int TAB_MAX_SIZE = 5;
 
     @Id

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -8,7 +8,6 @@ import org.hibernate.annotations.Where;
 import org.jetbrains.annotations.NotNull;
 
 import com.example.planservice.domain.BaseEntity;
-import com.example.planservice.domain.Linkable;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.exception.ApiException;
@@ -34,7 +33,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "is_deleted = false")
 @Getter
-public class Task extends BaseEntity implements Linkable<Task> {
+public class Task extends BaseEntity {
     public static final String FIRST_DUMMY_NAME = "first";
     public static final String LAST_DUMMY_NAME = "last";
 
@@ -120,7 +119,8 @@ public class Task extends BaseEntity implements Linkable<Task> {
 
         target.prev = this;
         this.next = target;
-        tab.getTasks().add(target);
+        tab.getTasks()
+            .add(target);
     }
 
     public void putInFront(@NotNull Task target) {
@@ -138,7 +138,8 @@ public class Task extends BaseEntity implements Linkable<Task> {
 
         target.next = this;
         this.prev = target;
-        tab.getTasks().add(target);
+        tab.getTasks()
+            .add(target);
     }
 
     public void disconnect() {
@@ -151,16 +152,19 @@ public class Task extends BaseEntity implements Linkable<Task> {
 
         this.prev = null;
         this.next = null;
-        tab.getTasks().remove(this);
+        tab.getTasks()
+            .remove(this);
     }
 
     public void validateCanModify() {
         Task firstDummyTask = tab.getFirstDummyTask();
-        if (this.getId().equals(firstDummyTask.getId())) {
+        if (this.getId()
+            .equals(firstDummyTask.getId())) {
             throw new ApiException(ErrorCode.TASK_NOT_FOUND);
         }
         Task lastDummyTask = tab.getLastDummyTask();
-        if (this.getId().equals(lastDummyTask.getId())) {
+        if (this.getId()
+            .equals(lastDummyTask.getId())) {
             throw new ApiException(ErrorCode.TASK_NOT_FOUND);
         }
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -110,4 +110,13 @@ public class PlanController {
             .build();
     }
 
+    @GetMapping("/all")
+    public ResponseEntity<List<PlanTitleIdResponse>> readPlanTitleIdList(@RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
+        return ResponseEntity.ok(planService.getAllPlanByMemberId(userId));
+    }
+
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -39,9 +39,7 @@ public class PlanController {
         }
         Long createdId = planService.create(request, userId);
         return ResponseEntity.created(URI.create("/plans/"))
-            .body(CreateResponse.builder()
-                .id(createdId)
-                .build());
+            .body(CreateResponse.of(createdId));
     }
 
     @GetMapping("/{planId}")

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.PlanService;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.request.PlanKickRequest;
 import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
 import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.PlanResponse;
@@ -73,14 +74,14 @@ public class PlanController {
             .build();
     }
 
-    @PutMapping("/kick/{planId}/{memberId}")
-    public ResponseEntity<Void> kick(@PathVariable Long planId, @PathVariable Long memberId,
+    @PutMapping("/kick/{planId}")
+    public ResponseEntity<Void> kick(@PathVariable Long planId, @RequestBody @Valid PlanKickRequest request,
                                      @RequestAttribute Long userId) {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();
         }
-        planService.kick(planId, memberId, userId);
+        planService.kick(planId, request, userId);
         return ResponseEntity.noContent()
             .build();
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -109,7 +109,7 @@ public class PlanController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<PlanTitleIdResponse>> readPlanTitleIdList(@RequestAttribute Long userId) {
+    public ResponseEntity<List<PlanTitleIdResponse>> readAllByMember(@RequestAttribute Long userId) {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -4,18 +4,19 @@ import java.net.URI;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.PlanService;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
 import com.example.planservice.presentation.dto.response.PlanResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,24 +28,79 @@ public class PlanController {
     private final PlanService planService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody @Valid PlanCreateRequest request,
-                                       @RequestHeader(value = "X-User-Id", required = false) Long userId) {
+    public ResponseEntity<Void> create(@RequestBody @Valid PlanCreateRequest request, @RequestAttribute Long userId) {
         if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
         }
         Long createdId = planService.create(request, userId);
-        return ResponseEntity.created(URI.create("/plans/" + createdId)).build();
+        return ResponseEntity.created(URI.create("/plans/" + createdId))
+            .build();
     }
 
     @GetMapping("/{planId}")
     public ResponseEntity<PlanResponse> read(@PathVariable Long planId, @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
         return ResponseEntity.ok(planService.getTotalPlanResponse(planId));
     }
 
     @PutMapping("/invite/{planId}")
     public ResponseEntity<Long> invite(@PathVariable Long planId, @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
         Long memberOfPlanId = planService.inviteMember(planId, userId);
         return ResponseEntity.ok(memberOfPlanId);
+    }
+
+    @PutMapping("/exit/{planId}")
+    public ResponseEntity<Void> exit(@PathVariable Long planId, @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
+        planService.exit(planId, userId);
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @PutMapping("/kick/{planId}/{memberId}")
+    public ResponseEntity<Void> kick(@PathVariable Long planId, @PathVariable Long memberId,
+                                     @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
+        planService.kick(planId, memberId, userId);
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @PutMapping("/update/{planId}")
+    public ResponseEntity<Void> update(@PathVariable Long planId, @RequestBody @Valid PlanUpdateRequest request,
+                                       @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
+        planService.update(planId, request, userId);
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<Void> delete(@PathVariable Long planId, @RequestAttribute Long userId) {
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .build();
+        }
+        planService.delete(planId, userId);
+        return ResponseEntity.ok()
+            .build();
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -1,6 +1,7 @@
 package com.example.planservice.presentation;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.planservice.application.PlanService;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
 import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
+import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.PlanResponse;
+import com.example.planservice.presentation.dto.response.PlanTitleIdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -28,14 +31,17 @@ public class PlanController {
     private final PlanService planService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody @Valid PlanCreateRequest request, @RequestAttribute Long userId) {
+    public ResponseEntity<CreateResponse> create(@RequestBody @Valid PlanCreateRequest request,
+                                                 @RequestAttribute Long userId) {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();
         }
         Long createdId = planService.create(request, userId);
-        return ResponseEntity.created(URI.create("/plans/" + createdId))
-            .build();
+        return ResponseEntity.created(URI.create("/plans/"))
+            .body(CreateResponse.builder()
+                .id(createdId)
+                .build());
     }
 
     @GetMapping("/{planId}")
@@ -53,8 +59,9 @@ public class PlanController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();
         }
-        Long memberOfPlanId = planService.inviteMember(planId, userId);
-        return ResponseEntity.ok(memberOfPlanId);
+        planService.inviteMember(planId, userId);
+        return ResponseEntity.noContent()
+            .build();
     }
 
     @PutMapping("/exit/{planId}")
@@ -64,7 +71,7 @@ public class PlanController {
                 .build();
         }
         planService.exit(planId, userId);
-        return ResponseEntity.ok()
+        return ResponseEntity.noContent()
             .build();
     }
 
@@ -76,19 +83,19 @@ public class PlanController {
                 .build();
         }
         planService.kick(planId, memberId, userId);
-        return ResponseEntity.ok()
+        return ResponseEntity.noContent()
             .build();
     }
 
     @PutMapping("/update/{planId}")
-    public ResponseEntity<Void> update(@PathVariable Long planId, @RequestBody @Valid PlanUpdateRequest request,
+    public ResponseEntity<Long> update(@PathVariable Long planId, @RequestBody @Valid PlanUpdateRequest request,
                                        @RequestAttribute Long userId) {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();
         }
         planService.update(planId, request, userId);
-        return ResponseEntity.ok()
+        return ResponseEntity.noContent()
             .build();
     }
 
@@ -99,7 +106,7 @@ public class PlanController {
                 .build();
         }
         planService.delete(planId, userId);
-        return ResponseEntity.ok()
+        return ResponseEntity.noContent()
             .build();
     }
 

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanKickRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanKickRequest.java
@@ -1,0 +1,19 @@
+package com.example.planservice.presentation.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PlanKickRequest {
+    private List<@Email String> kickingEmails;
+
+    @Builder
+    private PlanKickRequest(List<String> kickingEmails) {
+        this.kickingEmails = kickingEmails;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanKickRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanKickRequest.java
@@ -2,7 +2,6 @@ package com.example.planservice.presentation.dto.request;
 
 import java.util.List;
 
-import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +9,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PlanKickRequest {
-    private List<@Email String> kickingEmails;
+    private List<Long> kickingMemberIds;
 
     @Builder
-    private PlanKickRequest(List<String> kickingEmails) {
-        this.kickingEmails = kickingEmails;
+    private PlanKickRequest(List<Long> kickingMemberIds) {
+        this.kickingMemberIds = kickingMemberIds;
     }
+
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.example.planservice.presentation.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PlanUpdateRequest {
+    @NotNull
     private String title;
     private String intro;
+
+    @NotNull
     private boolean isPublic;
+
+    @NotNull
     private Long ownerId;
 
     @Builder

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.example.planservice.presentation.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PlanUpdateRequest {
+    private String title;
+    private String intro;
+    private boolean isPublic;
+    private Long ownerId;
+
+    @Builder
+    private PlanUpdateRequest(String title, String intro, boolean isPublic, Long ownerId) {
+        this.title = title;
+        this.intro = intro;
+        this.isPublic = isPublic;
+        this.ownerId = ownerId;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/CreateResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/CreateResponse.java
@@ -1,0 +1,16 @@
+package com.example.planservice.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class CreateResponse {
+    private Long id;
+
+    @Builder
+    private CreateResponse(Long id) {
+        this.id = id;
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/CreateResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/CreateResponse.java
@@ -13,4 +13,10 @@ public class CreateResponse {
     private CreateResponse(Long id) {
         this.id = id;
     }
+
+    public static CreateResponse of(Long id) {
+        return CreateResponse.builder()
+            .id(id)
+            .build();
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/LabelOfPlanResponse.java
@@ -17,7 +17,7 @@ public class LabelOfPlanResponse {
         this.value = value;
     }
 
-    public static LabelOfPlanResponse to(Label label) {
+    public static LabelOfPlanResponse from(Label label) {
         return builder()
             .id(label.getId())
             .value(label.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/MemberOfPlanResponse.java
@@ -23,7 +23,7 @@ public class MemberOfPlanResponse {
         this.isAdmin = isAdmin;
     }
 
-    public static MemberOfPlanResponse to(Member member, Long planAdminId) {
+    public static MemberOfPlanResponse from(Member member, Long planAdminId) {
         return builder()
             .id(member.getId())
             .name(member.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PlanResponse {
+    private Long id;
     private String title;
     private String description;
     private List<MemberOfPlanResponse> members;
@@ -21,9 +22,11 @@ public class PlanResponse {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private PlanResponse(String title, String description, List<MemberOfPlanResponse> members, List<Long> tabOrder,
+    private PlanResponse(Long id, String title, String description, List<MemberOfPlanResponse> members,
+                         List<Long> tabOrder,
                          List<TabOfPlanResponse> tabs, List<TaskOfPlanResponse> tasks, List<LabelOfPlanResponse> labels,
                          boolean isPublic) {
+        this.id = id;
         this.title = title;
         this.description = description;
         this.members = members;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanTitleIdResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/PlanTitleIdResponse.java
@@ -1,0 +1,27 @@
+package com.example.planservice.presentation.dto.response;
+
+
+import com.example.planservice.domain.plan.Plan;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PlanTitleIdResponse {
+    private Long id;
+    private String title;
+
+    @Builder
+    private PlanTitleIdResponse(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public static PlanTitleIdResponse from(Plan plan) {
+        return builder()
+            .id(plan.getId())
+            .title(plan.getTitle())
+            .build();
+    }
+}

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TabOfPlanResponse.java
@@ -21,7 +21,7 @@ public class TabOfPlanResponse {
         this.taskOrder = taskOrder;
     }
 
-    public static TabOfPlanResponse to(Tab tab, List<Long> taskOrder) {
+    public static TabOfPlanResponse from(Tab tab, List<Long> taskOrder) {
         return builder()
             .id(tab.getId())
             .title(tab.getName())

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -31,7 +31,7 @@ public class TaskOfPlanResponse {
         this.endDate = endDate;
     }
 
-    public static TaskOfPlanResponse to(Task task) {
+    public static TaskOfPlanResponse from(Task task) {
         return builder()
             .id(task.getId())
             .title(task.getName())

--- a/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
@@ -25,14 +25,17 @@ class EmailServiceTest {
         String recipient = "test@example.com";
         String text = "Hello, this is a test email.";
         EmailService emailServiceMock = Mockito.spy(emailService);
-        Mockito.doNothing().when(emailServiceMock).send(any(Message.class));
+        Mockito.doNothing()
+            .when(emailServiceMock)
+            .send(any(Message.class));
 
         // when
-        emailServiceMock.sendEmail(recipient, text);
+        emailServiceMock.sendInviteEmail(recipient, text, 1L);
 
         // then
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-        Mockito.verify(emailServiceMock, times(1)).send(messageCaptor.capture());
+        Mockito.verify(emailServiceMock, times(1))
+            .send(messageCaptor.capture());
         Message sentMessage = messageCaptor.getValue();
         assertEquals(sentMessage.getRecipients(Message.RecipientType.TO)[0].toString(), recipient);
         assertEquals(sentMessage.getSubject(), "Planting의 플랜에 초대되었습니다");

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -96,11 +96,38 @@ class PlanServiceTest {
 
         // then
         assertThat(savedId).isNotNull();
-
         Plan savedPlan = planRepository.findById(savedId)
             .get();
+
         assertThat(savedPlan.getTitle()).isEqualTo(request.getTitle());
         assertThat(savedPlan.getIntro()).isEqualTo(request.getIntro());
+    }
+
+    @Test
+    @DisplayName("플랜 생성시 기본 탭이 생성 되었다")
+    void createPlanWithDefaultTab() {
+        // given
+        List<String> invitedEmails = List.of("test@example.com");
+
+        PlanCreateRequest request = PlanCreateRequest.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .invitedEmails(invitedEmails)
+            .build();
+
+        // when
+        Long savedId = planService.create(request, userId);
+
+        // then
+        List<Tab> tabs = tabRepository.findAllByPlanId(savedId);
+        assertThat(tabs.size()).isEqualTo(3);
+        assertThat(tabs.get(0)
+            .getName()).isEqualTo("To Do");
+        assertThat(tabs.get(1)
+            .getName()).isEqualTo("In Progress");
+        assertThat(tabs.get(2)
+            .getName()).isEqualTo("Done");
     }
 
     @Test
@@ -206,13 +233,6 @@ class PlanServiceTest {
             .add(memberOfPlan1);
         plan.getMembers()
             .add(memberOfPlan2);
-
-        plan.getTasks()
-            .add(task1);
-        plan.getTasks()
-            .add(task2);
-        plan.getTasks()
-            .add(task3);
 
         plan.getLabels()
             .add(label1);

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -32,6 +32,7 @@ import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
 import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
 import com.example.planservice.presentation.dto.response.PlanResponse;
+import com.example.planservice.presentation.dto.response.PlanTitleIdResponse;
 
 @SpringBootTest
 @Transactional
@@ -73,8 +74,8 @@ class PlanServiceTest {
 
         Mockito.doNothing()
             .when(emailService)
-            .sendEmail(ArgumentMatchers.anyString(),
-                ArgumentMatchers.anyString());
+            .sendInviteEmail(ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyLong());
     }
 
     @Test
@@ -143,6 +144,7 @@ class PlanServiceTest {
             .title("testPlan")
             .intro("hi")
             .build();
+
 
         Tab tab2 = Tab.builder()
             .plan(plan)
@@ -300,7 +302,7 @@ class PlanServiceTest {
         Long memberOfPlanId = planService.inviteMember(plan.getId(), member.getId());
 
         // then
-        assertThat(memberOfPlanId).isNotNull();
+        assertThat(memberOfPlanRepository.findById(memberOfPlanId)).isPresent();
     }
 
     @Test
@@ -333,6 +335,8 @@ class PlanServiceTest {
             .name("tester")
             .email("test@example.com")
             .build();
+
+
         Member savedMember = memberRepository.save(member);
 
         // when & then
@@ -348,19 +352,14 @@ class PlanServiceTest {
     @DisplayName("플랜을 삭제한다")
     void delete() {
         // given
-        Plan plan = Plan.builder()
-            .title("플랜 제목")
-            .intro("플랜 소개")
-            .isPublic(true)
-            .build();
-        Plan savedPlan = planRepository.save(plan);
+        Plan plan = creatDefaultPlan("testPlan");
+        saveDefaultMemberOfPlan(plan, tester);
 
         // when
-        planService.delete(savedPlan.getId(), userId);
+        planService.delete(plan.getId(), tester.getId());
 
         // then
-        assertThat(planRepository.findById(savedPlan.getId())
-            .isPresent()).isFalse();
+        assertThat(plan.isDeleted()).isEqualTo(true);
     }
 
     @Test
@@ -405,32 +404,79 @@ class PlanServiceTest {
     @DisplayName("플랜에서 나간다")
     void exit() {
         // given
-        Member exitMember = Member.builder()
-            .name("nextOwner")
-            .email("test@test.com")
-            .build();
-
         Plan plan = Plan.builder()
             .title("플랜 제목")
             .intro("플랜 소개")
-            .owner(tester)
             .isPublic(true)
             .build();
-
-        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
-            .member(exitMember)
-            .plan(plan)
-            .build();
-        memberRepository.save(exitMember);
         planRepository.save(plan);
-        memberOfPlanRepository.save(memberOfPlan);
+
+        Member member = Member.builder()
+            .name("tester")
+            .email("test@example.com")
+            .build();
+        memberRepository.save(member);
+        Long memberOfPlanId = planService.inviteMember(plan.getId(), member.getId());
 
         // when
-        planService.exit(plan.getId(), userId);
+        planService.exit(plan.getId(), member.getId());
 
         // then
-        assertThat(memberOfPlanRepository.findById(memberOfPlan.getId())
-            .isPresent()).isFalse();
+        assertThat(memberOfPlanRepository.findById(memberOfPlanId)).isEmpty();
+        assertThat(planService.getAllPlanByMemberId(member.getId())).isEmpty();
+    }
 
+
+    @Test
+    @DisplayName("멤버 아이디로 모든 플랜을 가져온다")
+    void getAllPlanByMemberId() {
+        // given
+        Member member = createDefaultMember();
+        Plan plan1 = creatDefaultPlan("plan1");
+        Plan plan2 = creatDefaultPlan("plan2");
+        Plan plan3 = creatDefaultPlan("plan3");
+        saveDefaultMemberOfPlan(plan1, member);
+        saveDefaultMemberOfPlan(plan2, member);
+        saveDefaultMemberOfPlan(plan3, member);
+
+        // when
+        List<PlanTitleIdResponse> allPlanByMemberId = planService.getAllPlanByMemberId(member.getId());
+
+        // then
+        assertThat(allPlanByMemberId.size()).isEqualTo(3);
+        assertThat(allPlanByMemberId.get(0)
+            .getTitle()).isEqualTo("plan1");
+        assertThat(allPlanByMemberId.get(1)
+            .getTitle()).isEqualTo("plan2");
+        assertThat(allPlanByMemberId.get(2)
+            .getTitle()).isEqualTo("plan3");
+
+    }
+
+    private Plan creatDefaultPlan(String planTitle) {
+        return planRepository.save(Plan.builder()
+            .title(planTitle)
+            .intro("플랜 소개")
+            .owner(tester)
+            .isPublic(true)
+            .build());
+    }
+
+    private Member createDefaultMember() {
+        return memberRepository.save(Member.builder()
+            .name("tester1")
+            .email("tester@example.com")
+            .build());
+    }
+
+    private void saveDefaultMemberOfPlan(Plan plan, Member member) {
+
+        MemberOfPlan memberOfPlan = MemberOfPlan.builder()
+            .member(member)
+            .plan(plan)
+            .build();
+        plan.getMembers()
+            .add(memberOfPlan);
+        memberOfPlanRepository.save(memberOfPlan);
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.example.planservice.domain.memberofplan.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -32,9 +34,11 @@ class MemberOfPlanRepositoryTest {
     @DisplayName("planId와 memberId로 해당되는 MemberOfPlan 인스턴스를 찾는다")
     void testFindByPlanIdAndMemberId() {
         // given
-        Member member = Member.builder().build();
+        Member member = Member.builder()
+            .build();
         memberRepository.save(member);
-        Plan plan = Plan.builder().build();
+        Plan plan = Plan.builder()
+            .build();
         planRepository.save(plan);
         MemberOfPlan memberOfPlan = MemberOfPlan.builder()
             .member(member)
@@ -44,7 +48,8 @@ class MemberOfPlanRepositoryTest {
 
         // when
         MemberOfPlan result =
-            memberOfPlanRepository.findByPlanIdAndMemberId(plan.getId(), member.getId()).get();
+            memberOfPlanRepository.findByPlanIdAndMemberId(plan.getId(), member.getId())
+                .get();
 
         // then
         assertThat(result.getMember()).isEqualTo(member);
@@ -55,9 +60,11 @@ class MemberOfPlanRepositoryTest {
     @DisplayName("planId와 memberId로 해당되는 MemberOfPlan 엔티티가 없으면 Optional.empty()를 반환한다")
     void testFindByPlanIdAndMemberIdFail() {
         // given
-        Member member = Member.builder().build();
+        Member member = Member.builder()
+            .build();
         memberRepository.save(member);
-        Plan plan = Plan.builder().build();
+        Plan plan = Plan.builder()
+            .build();
         planRepository.save(plan);
 
         // when
@@ -69,4 +76,62 @@ class MemberOfPlanRepositoryTest {
         assertThat(memberOfPlanOpt).isEmpty();
     }
 
+    @Test
+    @DisplayName("planId와 여러개의 memberId로 해당되는 MemberOfPlan 엔티티를 삭제한다")
+    void deleteAllByPlanIdAndMemberIdsTest() {
+        // Given
+        Member member1 = Member.createNormalUser()
+            .profileUri("profile1")
+            .name("name1")
+            .email("email1")
+            .receiveEmails(true)
+            .build();
+        Member member2 = Member.createNormalUser()
+            .profileUri("profile2")
+            .name("name2")
+            .email("email2")
+            .receiveEmails(true)
+            .build();
+        Member member3 = Member.createNormalUser()
+            .profileUri("profile3")
+            .name("name3")
+            .email("email3")
+            .receiveEmails(true)
+            .build();
+
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        Plan plan = Plan.builder()
+            .owner(member1)
+            .title("title")
+            .intro("intro")
+            .isPublic(true)
+            .starCnt(0)
+            .viewCnt(0)
+            .isDeleted(false)
+            .build();
+
+        plan = planRepository.save(plan);
+
+        MemberOfPlan memberOfPlan1 = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member2)
+            .build();
+
+        MemberOfPlan memberOfPlan2 = MemberOfPlan.builder()
+            .plan(plan)
+            .member(member3)
+            .build();
+
+        memberOfPlanRepository.saveAll(List.of(memberOfPlan1, memberOfPlan2));
+
+        // When
+        memberOfPlanRepository.deleteAllByPlanIdAndMemberIds(plan.getId(),
+            List.of(member2.getId(), member3.getId()));
+
+        // Then
+        List<MemberOfPlan> membersOfPlan = memberOfPlanRepository.findAllByPlanId(plan.getId())
+            .get();
+        assertEquals(0, membersOfPlan.size());
+    }
 }

--- a/plan-service/src/test/java/com/example/planservice/domain/plan/PlanTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/plan/PlanTest.java
@@ -2,11 +2,14 @@ package com.example.planservice.domain.plan;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import com.example.planservice.domain.member.Member;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.example.planservice.domain.member.Member;
+
 class PlanTest {
+
 
     @Test
     @DisplayName("플랜을 생성한다")
@@ -31,4 +34,45 @@ class PlanTest {
         assertThat(plan.getIntro()).isEqualTo("플랜 소개");
         assertThat(plan.isPublic()).isTrue();
     }
+
+    @Test
+    @DisplayName("플랜을 수정한다")
+    void updatePlan() {
+        //given
+        Member prevOwner = mock(Member.class);
+        Member nextOwner = mock(Member.class);
+        Plan plan = Plan.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .owner(prevOwner)
+            .isPublic(true)
+            .build();
+
+        //when
+        plan.update("수정된 플랜 제목", "수정된 플랜 소개", nextOwner, false);
+
+        //then
+        assertThat(plan.getTitle()).isEqualTo("수정된 플랜 제목");
+        assertThat(plan.getIntro()).isEqualTo("수정된 플랜 소개");
+        assertThat(plan.getOwner()).isEqualTo(nextOwner);
+        assertThat(plan.isPublic()).isFalse();
+    }
+
+    @Test
+    @DisplayName("플랜을 삭제한다")
+    void deletePlan() {
+        //given
+        Plan plan = Plan.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .build();
+
+        //when
+        plan.softDelete();
+
+        //then
+        assertThat(plan.isDeleted()).isTrue();
+    }
+
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -4,7 +4,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,9 +56,7 @@ class PlanControllerTest {
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isCreated())
-            .andExpect(header().exists("Location"))
-            .andExpect(redirectedUrlPattern("/plans/*"));
+            .andExpect(status().isCreated());
     }
 
     @Test
@@ -157,8 +156,7 @@ class PlanControllerTest {
         mockMvc.perform(put("/plans/invite/{planId}", planId)
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string("1"));
+            .andExpect(status().isNoContent());
     }
 
     @Test
@@ -191,7 +189,7 @@ class PlanControllerTest {
         mockMvc.perform(put("/plans/exit/{planId}", planId)
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+            .andExpect(status().isNoContent());
     }
 
     @Test
@@ -232,31 +230,7 @@ class PlanControllerTest {
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 플랜 ID로 플랜 정보를 수정하면 실패한다")
-    void updatePlanFailInvalidId() throws Exception {
-        // given
-        Long userId = 1L;
-        Long invalidPlanId = 9999L;
-
-        PlanUpdateRequest request = PlanUpdateRequest.builder()
-            .title("플랜 제목")
-            .intro("플랜 소개")
-            .isPublic(true)
-            .build();
-
-        // stub
-        when(planService.update(invalidPlanId, request, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
-
-        // when & then
-        mockMvc.perform(put("/plans/update/{planId}", invalidPlanId)
-                .header("X-User-Id", userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isNotFound());
+            .andExpect(status().isNoContent());
     }
 
     @Test
@@ -273,7 +247,23 @@ class PlanControllerTest {
         mockMvc.perform(delete("/plans/{planId}", planId)
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+            .andExpect(status().isNoContent());
     }
 
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 플랜을 삭제하면 실패한다")
+    void deletePlanFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long invalidPlanId = 9999L;
+
+        // stub
+        when(planService.delete(invalidPlanId, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(delete("/plans/{planId}", invalidPlanId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -21,6 +21,7 @@ import com.example.planservice.application.PlanService;
 import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
+import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
 import com.example.planservice.presentation.dto.response.PlanResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -174,6 +175,105 @@ class PlanControllerTest {
                 .header("X-User-Id", userId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("플랜에서 나간다")
+    void exitPlan() throws Exception {
+        // given
+        Long userId = 1L;
+        Long planId = 1L;
+
+        // stub
+        when(planService.exit(planId, userId)).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(put("/plans/exit/{planId}", planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 플랜에서 나가면 실패한다")
+    void exitPlanFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long invalidPlanId = 9999L;
+
+        // stub
+        when(planService.exit(invalidPlanId, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(put("/plans/exit/{planId}", invalidPlanId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("플랜 정보를 수정한다")
+    void updatePlan() throws Exception {
+        // given
+        Long userId = 1L;
+        Long planId = 1L;
+
+        PlanUpdateRequest request = PlanUpdateRequest.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .build();
+
+        // stub
+        when(planService.update(planId, request, userId)).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(put("/plans/update/{planId}", planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜 ID로 플랜 정보를 수정하면 실패한다")
+    void updatePlanFailInvalidId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long invalidPlanId = 9999L;
+
+        PlanUpdateRequest request = PlanUpdateRequest.builder()
+            .title("플랜 제목")
+            .intro("플랜 소개")
+            .isPublic(true)
+            .build();
+
+        // stub
+        when(planService.update(invalidPlanId, request, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(put("/plans/update/{planId}", invalidPlanId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("플랜을 삭제한다")
+    void deletePlan() throws Exception {
+        // given
+        Long userId = 1L;
+        Long planId = 1L;
+
+        // stub
+        when(planService.delete(planId, userId)).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(delete("/plans/{planId}", planId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
     }
 
 }

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -71,7 +71,7 @@ class PlanControllerTest {
         invitedEmails.add("B@gmail.com");
 
         PlanCreateRequest request = PlanCreateRequest.builder()
-            .title("플랜 제목")
+            .title("플랜 `제목")
             .intro("플랜 소개")
             .isPublic(true)
             .invitedEmails(invitedEmails)
@@ -226,6 +226,7 @@ class PlanControllerTest {
             .title("플랜 제목")
             .intro("플랜 소개")
             .isPublic(true)
+            .ownerId(userId)
             .build();
 
         // stub


### PR DESCRIPTION
## 📌 Description
- 플랜 설정 API
- 플랜 나가기 API
- 플랜 추방 API
- 멤버가 속한 플랜 조회 API 구현
- 리팩토링
  - put,delete 요청은 noContent로 반환
  - create 시 planId body로 반환
  - planservice에서 createDefaultTab 만드는 과정 TabService의 기능으로 위임 -> 이부분은 제대로 동작하는지 프론트와의 연동을 통해 확인해 볼 필요가 있습니다. 
  - tabOrder, taskOrder 가져오는 과정 분리 , Linkable 삭제
  - 
## ⚠️ 주의사항

close #29 
close #30 
close #33 
close #86
close #87
close #88
