### PR TITLE
[#77] 태스크 단건 조회 기능 구현

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -20,6 +20,7 @@ import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 import com.example.planservice.presentation.dto.request.TaskChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+import com.example.planservice.presentation.dto.response.TaskFindResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -111,6 +112,17 @@ public class TaskService {
         }
         return taskRepository.findById(prevId)
             .orElseThrow(() -> new ApiException(ErrorCode.TASK_NOT_FOUND));
+    }
+
+    public TaskFindResponse find(Long taskId, Long memberId) {
+        Task task = taskRepository.findById(taskId)
+            .orElseThrow(() -> new ApiException(ErrorCode.TASK_NOT_FOUND));
+        Tab tab = task.getTab();
+        Plan plan = tab.getPlan();
+        if (!plan.isPublic()) {
+            planMembershipService.validateMemberIsInThePlan(memberId, plan);
+        }
+        return TaskFindResponse.from(task);
     }
 
     private void saveAllLabelOfTask(List<Long> labelIds, Task task, Plan plan) {

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -55,7 +55,7 @@ public class Task extends BaseEntity implements Linkable<Task> {
     @JoinColumn(name = "writer_id")
     private Member writer;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "task")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "task")
     private List<LabelOfTask> labelOfTasks = new ArrayList<>();
 
     private String name;

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -112,13 +112,13 @@ public class Task extends BaseEntity implements Linkable<Task> {
         Task originalNext = this.next;
         if (originalNext == null) {
             this.next = target;
-            target.prev = this;
+            target.setPrev(this);
             return;
         }
-        originalNext.prev = target;
-        target.next = originalNext;
+        originalNext.setPrev(target);
+        target.setNext(originalNext);
 
-        target.prev = this;
+        target.setPrev(this);
         this.next = target;
         tab.getTasks().add(target);
     }
@@ -130,13 +130,13 @@ public class Task extends BaseEntity implements Linkable<Task> {
         Task originalPrev = this.prev;
         if (originalPrev == null) {
             this.prev = target;
-            target.next = this;
+            target.setNext(this);
             return;
         }
-        originalPrev.next = target;
-        target.prev = originalPrev;
+        originalPrev.setNext(target);
+        target.setPrev(originalPrev);
 
-        target.next = this;
+        target.setNext(this);
         this.prev = target;
         tab.getTasks().add(target);
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +17,7 @@ import com.example.planservice.application.TaskService;
 import com.example.planservice.presentation.dto.request.TaskChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TaskCreateRequest;
 import com.example.planservice.presentation.dto.request.TaskUpdateRequest;
+import com.example.planservice.presentation.dto.response.TaskFindResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -51,6 +53,12 @@ public class TaskController {
     public ResponseEntity<Void> delete(@PathVariable Long taskId, @RequestAttribute Long userId) {
         taskService.delete(userId, taskId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{taskId}")
+    public ResponseEntity<TaskFindResponse> find(@PathVariable Long taskId,
+                                                 @RequestAttribute Long userId) {
+        return ResponseEntity.ok(taskService.find(taskId, userId));
     }
 
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
@@ -1,0 +1,83 @@
+package com.example.planservice.presentation.dto.response;
+
+import com.example.planservice.domain.tab.Tab;
+import com.example.planservice.domain.task.Task;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+@NoArgsConstructor
+@Getter
+public class TaskFindResponse {
+    private Long id;
+
+    private Long tabId;
+
+    private Long planId;
+
+    private Long managerId;
+
+    private List<Long> labels;
+
+    private String name;
+
+    private String description;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private Long nextId;
+
+    private Long prevId;
+
+    @Builder
+    @SuppressWarnings("java:S107")
+    public TaskFindResponse(Long id, Long tabId, Long planId, Long managerId, List<Long> labels, String name,
+                            String description, LocalDateTime startDate, LocalDateTime endDate, Long nextId,
+                            Long prevId) {
+        this.id = id;
+        this.tabId = tabId;
+        this.planId = planId;
+        this.managerId = managerId;
+        this.labels = labels;
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.nextId = nextId;
+        this.prevId = prevId;
+    }
+
+    public static TaskFindResponse from(Task task) {
+        Tab tab = task.getTab();
+        List<Long> labels = task.getLabelOfTasks().stream()
+            .map(labelOfTask -> labelOfTask.getLabel().getId())
+            .toList();
+        Long nextId = null;
+        Long prevId = null;
+        if (!Objects.equals(task.getNext(), tab.getLastDummyTask())) {
+            nextId = task.getNext().getId();
+        }
+        if (!Objects.equals(task.getPrev(), tab.getFirstDummyTask())) {
+            prevId = task.getPrev().getId();
+        }
+        return TaskFindResponse.builder()
+            .id(task.getId())
+            .tabId(tab.getId())
+            .planId(tab.getPlan().getId())
+            .managerId(task.getManager() != null ? task.getManager().getId() : null)
+            .labels(labels)
+            .name(task.getName())
+            .description(task.getDescription())
+            .startDate(task.getStartDate())
+            .endDate(task.getEndDate())
+            .nextId(nextId)
+            .prevId(prevId)
+            .build();
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
@@ -2,8 +2,8 @@ package com.example.planservice.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.planservice.application.TaskService;
 import com.example.planservice.presentation.dto.request.TaskCreateRequest;
+import com.example.planservice.presentation.dto.response.TaskFindResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {TaskController.class})
@@ -43,7 +44,7 @@ class TaskControllerTest {
         Long userId = 2L;
 
         // stub
-        Mockito.when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
+        when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
             .thenReturn(createdId);
 
         // when & then
@@ -81,7 +82,7 @@ class TaskControllerTest {
         Long userId = 2L;
 
         // stub
-        Mockito.when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
+        when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
             .thenReturn(createdId);
 
         // when & then
@@ -104,7 +105,7 @@ class TaskControllerTest {
         Long userId = 2L;
 
         // stub
-        Mockito.when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
+        when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
             .thenReturn(createdId);
 
         // when & then
@@ -128,7 +129,7 @@ class TaskControllerTest {
         Long userId = 2L;
 
         // stub
-        Mockito.when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
+        when(taskService.create(anyLong(), any(TaskCreateRequest.class)))
             .thenReturn(createdId);
 
         // when & then
@@ -162,4 +163,37 @@ class TaskControllerTest {
             .andExpect(status().isUnauthorized());
     }
 
+    @Test
+    @DisplayName("태스크를 조회한다")
+    void testFindTask() throws Exception {
+        // given
+        Long userId = 2L;
+        Long taskId = 1L;
+
+        TaskFindResponse response = TaskFindResponse.builder()
+            .id(taskId)
+            .name("이름")
+            .build();
+
+        // stub
+        when(taskService.find(anyLong(), anyLong()))
+            .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/tasks/" + taskId)
+                .header("X-User-Id", userId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(response.getId()))
+            .andExpect(jsonPath("$.name").value(response.getName()));
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 태스크를 조회할 수 없다")
+    void testFindTaskFailNotLogin() throws Exception {
+        Long taskId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/tasks/" + taskId))
+            .andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
## 📌 Description
1. Task 엔티티에 있는 labelOfTasks 필드의 Fetch 타입을 Eager로 바꿨습니다.
Task를 조회할 때 LabelOfTask에 대한 정보를 항상 필요로 하는 거처럼 보였기 때문입니다.

2. Task 엔티티의 putInBack과 putInFront 메서드가 정상동작하지 않고 있더군요...
테스트를 다시 꼼꼼하게 해야 하나 고민중입니다. Task의 connect 관련된 기능들에 대해 테스트를 느슨하게 했는데 이런 사단이 생겨버렸네요.

## ⚠️ 주의사항
TaskServiceTest의 testFindTask() 메서드를 일부분 가져왔습니다.
```
        // given
        Plan plan = createPlan();
        Tab tab = createTab(plan);
        Task task = createTaskWithTab(tab);
        Task nextTask = createTaskWithTab(tab);
        Member member = createMemberWithPlan(plan);
        Label label1 = createLabelUsingTest(plan);
        labelOfTaskRepository.save(LabelOfTask.builder().task(task).label(label1).build());
        em.flush();
        em.clear();
```
해당 메서드 내부에서 em.flush(), em.clear()를 진행하고 있습니다.
이유는 Task 엔티티의 labelOfTask의 Fetch Type이 Eager이기 때문입니다.

간략하게 테스트를 설명하면
1. tas를 만들고 label1을 만들었습니다.
2. task에 label1을 달아주기 위해 `labelOfTaskRepository.save(LabelOfTask.builder().task(task).label(label1).build());` 를 수행했습니다.

만약 em.flush, em.clear를 하지 않으면 tab 조회 시 labelOfTasks 내부에 2번에서 저장해준 LabelOfTask 엔티티가 보이지 않습니다.
그 이유는 labelOfTaskRepository에서 save를 한다고, 이미 영속성 컨텍스트에 위치하던 task는 해당 변경을 인지하지 못하기 때문입니다.

그래서 영속성 컨텍스트를 DB에 반영한 뒤, 영속성 컨텍스트를 날렸습니다.
이후, 테스트 수행 시 DB에 새롭게 쿼리를 날려 값을 가져오기 때문에 원하는 테스트 환경을 구성할 수 있습니다.


close #77
