### PR TITLE
[#104, #105] 플랜 초대 로직 및 플랜 수정 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
 
     processResources {
         filesMatching("**/application.yml") {
-            expand(project: project.name, profileLevel: "local")
+            expand(project: project.name, profileLevel: "docker")
         }
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,3 +63,8 @@ services:
       - ${MYSQL_PORT}:${MYSQL_PORT}
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  redis:
+    image: redis:latest
+    ports:
+      - ${REDIS_PORT}:${REDIS_PORT}

--- a/plan-service/build.gradle
+++ b/plan-service/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.sun.mail:javax.mail:1.6.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/plan-service/src/main/java/com/example/planservice/application/EmailService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/EmailService.java
@@ -10,6 +10,7 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.example.planservice.config.MailProperties;
@@ -23,6 +24,8 @@ public class EmailService {
 
     private final Session session;
     private final MailProperties mailProperties;
+    @Value("${service-url}")
+    private String url;
 
     @Autowired
     public EmailService(MailProperties mailProperties) {
@@ -30,7 +33,7 @@ public class EmailService {
         session = createSession();
     }
 
-    public void sendInviteEmail(String to, String text, Long userId) {
+    public void sendInviteEmail(String to, String text, String uuid) {
         try {
             Message message = new MimeMessage(session);
             message.setFrom(new InternetAddress(mailProperties.getUsername()));
@@ -38,7 +41,7 @@ public class EmailService {
             message.setSubject(INVITING_SUBJECT);
             String content = text + ' ' + INVITING_ANNOUNCEMENT;
             content += "<br>";
-            content += "http://localhost/invite" + userId;
+            content += url + uuid;
 
             message.setContent(content, "text/html; charset=utf-8");
 
@@ -60,5 +63,4 @@ public class EmailService {
             }
         });
     }
-
 }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -158,13 +158,11 @@ public class PlanService {
         validateOwner(plan.getOwner()
             .getId(), userId);
 
-        if (!request.getInvitedEmails()
-            .isEmpty()) {
+        if (!request.getInvitedEmails().isEmpty()) {
             sendInviteMail(request.getInvitedEmails(), request.getTitle(), userId);
         }
 
-        if (!request.getKickingMemberIds()
-            .isEmpty()) {
+        if (!request.getKickingMemberIds().isEmpty()) {
             kick(planId, request.getKickingMemberIds());
         }
 
@@ -201,8 +199,7 @@ public class PlanService {
         requireNonNull(title, "플랜 제목을 입력해주세요");
         requireNonNull(planId, "플랜 아이디를 입력해주세요");
 
-        String uuid = UUID.randomUUID()
-            .toString();
+        String uuid = UUID.randomUUID().toString();
         savePlanIdToRedis(uuid, planId);
         invitedEmails.forEach(email -> emailService.sendInviteEmail(email, title, uuid));
     }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -312,6 +312,9 @@ public class PlanService {
     }
 
     private void savePlanIdToRedis(String uuid, Long planId) {
+        if (redisUtils.hasKey(uuid)) {
+            uuid = UUID.randomUUID().toString();
+        }
         redisUtils.setData(uuid, planId.toString(), 1000L * 60 * 60 * 24);
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/application/PlanService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/PlanService.java
@@ -139,9 +139,28 @@ public class PlanService {
             .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
         validateOwner(plan.getOwner()
             .getId(), userId);
+
+        if (!request.getInvitedEmails()
+            .isEmpty()) {
+            sendInviteMail(request.getInvitedEmails(), request.getTitle(), userId);
+        }
+
+        if (!request.getKickingMemberIds()
+            .isEmpty()) {
+            kick(planId, request.getKickingMemberIds());
+        }
+
+
         Member nextOwner = memberRepository.findById(request.getOwnerId())
             .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
         plan.update(request.getTitle(), request.getIntro(), nextOwner, request.isPublic());
+
+        planRepository.save(plan);
+
+    }
+
+    public void kick(Long planId, List<Long> kinkingMemberIds) {
+        memberOfPlanRepository.deleteAllByPlanIdAndMemberIds(planId, kinkingMemberIds);
     }
 
     public List<PlanTitleIdResponse> getAllPlanTitleIdByMemberId(Long userId) {

--- a/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepository.java
@@ -24,4 +24,6 @@ public interface MemberOfPlanRepository extends JpaRepository<MemberOfPlan, Long
     void deleteAllByPlanIdAndMemberIds(@Param("planId") Long planId, @Param("memberIds") List<Long> memberIds);
 
     Optional<List<MemberOfPlan>> findAllByPlanId(Long id);
+
+    boolean existsByPlanIdAndMemberId(Long planId, Long memberId);
 }

--- a/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
+++ b/plan-service/src/main/java/com/example/planservice/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜이 존재하지 않습니다"),
     PLAN_TAB_MISMATCH(HttpStatus.BAD_REQUEST, "플랜과 탭 사이 관계가 없습니다"),
     MEMBER_NOT_FOUND_IN_PLAN(HttpStatus.FORBIDDEN, "플랜에 소속되지 않은 멤버입니다"),
+    MEMBER_ALREADY_IN_PLAN(HttpStatus.BAD_REQUEST, "이미 플랜에 소속된 멤버입니다"),
 
     // 탭
     TAB_NOT_FOUND(HttpStatus.NOT_FOUND, "탭을 찾을 수 없습니다"),

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -51,13 +51,14 @@ public class PlanController {
         return ResponseEntity.ok(planService.getTotalPlanResponse(planId));
     }
 
-    @PutMapping("/invite/{planId}")
-    public ResponseEntity<Long> invite(@PathVariable Long planId, @RequestAttribute Long userId) {
+    @PutMapping("/invite/{uuid}")
+    public ResponseEntity<Long> invite(@PathVariable String uuid, @RequestAttribute Long userId) {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .build();
         }
-        planService.inviteMember(planId, userId);
+
+        planService.inviteMember(uuid, userId);
         return ResponseEntity.noContent()
             .build();
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/PlanController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.planservice.application.PlanService;
 import com.example.planservice.presentation.dto.request.PlanCreateRequest;
-import com.example.planservice.presentation.dto.request.PlanKickRequest;
 import com.example.planservice.presentation.dto.request.PlanUpdateRequest;
 import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.PlanResponse;
@@ -70,18 +69,6 @@ public class PlanController {
                 .build();
         }
         planService.exit(planId, userId);
-        return ResponseEntity.noContent()
-            .build();
-    }
-
-    @PutMapping("/kick/{planId}")
-    public ResponseEntity<Void> kick(@PathVariable Long planId, @RequestBody @Valid PlanKickRequest request,
-                                     @RequestAttribute Long userId) {
-        if (userId == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .build();
-        }
-        planService.kick(planId, request, userId);
         return ResponseEntity.noContent()
             .build();
     }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
@@ -1,5 +1,9 @@
 package com.example.planservice.presentation.dto.request;
 
+import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/PlanUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.example.planservice.presentation.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,11 +19,18 @@ public class PlanUpdateRequest {
     @NotNull
     private Long ownerId;
 
+    private List<@Email String> invitedEmails;
+    private List<Long> kickingMemberIds;
+
     @Builder
-    private PlanUpdateRequest(String title, String intro, boolean isPublic, Long ownerId) {
+    private PlanUpdateRequest(String title, String intro, boolean isPublic, Long ownerId, List<String> invitedEmails,
+                              List<Long> kickingMemberIds) {
         this.title = title;
         this.intro = intro;
         this.isPublic = isPublic;
         this.ownerId = ownerId;
+        this.invitedEmails = invitedEmails;
+        this.kickingMemberIds = kickingMemberIds;
+
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
+++ b/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
@@ -15,13 +15,11 @@ public class RedisUtils {
     }
 
     public void setData(String key, String value, Long expiredTime) {
-        redisTemplate.opsForValue()
-            .set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
     }
 
     public String getData(String key) {
-        return (String) redisTemplate.opsForValue()
-            .get(key);
+        return (String) redisTemplate.opsForValue().get(key);
     }
 
     public void deleteData(String key) {

--- a/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
+++ b/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
@@ -25,4 +25,8 @@ public class RedisUtils {
     public void deleteData(String key) {
         redisTemplate.delete(key);
     }
+
+    public Boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
 }

--- a/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
+++ b/plan-service/src/main/java/com/example/planservice/util/RedisUtils.java
@@ -1,0 +1,30 @@
+package com.example.planservice.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisUtils {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisUtils(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setData(String key, String value, Long expiredTime) {
+        redisTemplate.opsForValue()
+            .set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    public String getData(String key) {
+        return (String) redisTemplate.opsForValue()
+            .get(key);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
@@ -25,6 +25,7 @@ class EmailServiceTest {
 
     @Test
     void sendEmail() throws MessagingException {
+
         // given
         String recipient = "test@example.com";
         String text = "Hello, this is a test email.";
@@ -34,7 +35,7 @@ class EmailServiceTest {
             .send(any(Message.class));
 
         // when
-        emailServiceMock.sendInviteEmail(recipient, text, 1L);
+        emailServiceMock.sendInviteEmail(recipient, text, "uuid");
 
         // then
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);

--- a/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/EmailServiceTest.java
@@ -12,8 +12,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.example.planservice.config.TestConfig;
 
 @SpringBootTest
+@Import(TestConfig.class)
 class EmailServiceTest {
 
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/LabelServiceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.LabelDeleteServiceRequest;
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -21,6 +23,7 @@ import com.example.planservice.presentation.dto.response.LabelFindResponse;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class LabelServiceTest {
     @Autowired
@@ -265,7 +268,8 @@ class LabelServiceTest {
     }
 
     private Member createMemberUsingTest(Plan plan) {
-        Member member = Member.builder().build();
+        Member member = Member.builder()
+            .build();
         em.persist(member);
         if (plan == null) {
             return member;

--- a/plan-service/src/test/java/com/example/planservice/application/MemberServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/MemberServiceTest.java
@@ -7,10 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.MemberRegisterResponse;
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.Role;
 import com.example.planservice.exception.ApiException;
@@ -20,8 +21,8 @@ import com.example.planservice.presentation.dto.response.MemberFindResponse;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
-@ActiveProfiles("test")
 class MemberServiceTest {
     @Autowired
     MemberService memberService;
@@ -67,7 +68,9 @@ class MemberServiceTest {
     void testRegisterFailDuplicatedEmail() throws Exception {
         // given
         String duplicatedEmail = "a@naver.com";
-        Member member = Member.builder().email(duplicatedEmail).build();
+        Member member = Member.builder()
+            .email(duplicatedEmail)
+            .build();
         em.persist(member);
 
         MemberRegisterRequest request = MemberRegisterRequest.builder()

--- a/plan-service/src/test/java/com/example/planservice/application/PlanMembershipServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanMembershipServiceTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -20,6 +22,7 @@ import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class PlanMembershipServiceTest {
     @Autowired
@@ -79,7 +82,9 @@ class PlanMembershipServiceTest {
     void testValidatePlanOwner() {
         // given
         Member member = createMember();
-        Plan plan = Plan.builder().owner(member).build();
+        Plan plan = Plan.builder()
+            .owner(member)
+            .build();
         planRepository.save(plan);
 
         // when
@@ -95,7 +100,9 @@ class PlanMembershipServiceTest {
         // given
         Member member = createMember();
         Member otherMember = createMember();
-        Plan plan = Plan.builder().owner(member).build();
+        Plan plan = Plan.builder()
+            .owner(member)
+            .build();
         planRepository.save(plan);
 
         // when
@@ -183,7 +190,8 @@ class PlanMembershipServiceTest {
 
     @NotNull
     private Plan createPlan() {
-        Plan plan = Plan.builder().build();
+        Plan plan = Plan.builder()
+            .build();
         planRepository.save(plan);
         return plan;
     }

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -2,19 +2,23 @@ package com.example.planservice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.label.repository.LabelRepository;
 import com.example.planservice.domain.member.Member;
@@ -35,6 +39,7 @@ import com.example.planservice.presentation.dto.response.PlanResponse;
 import com.example.planservice.presentation.dto.response.PlanTitleIdResponse;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class PlanServiceTest {
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TabServiceTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.TabChangeTitleResponse;
 import com.example.planservice.application.dto.TabChangeTitleServiceRequest;
 import com.example.planservice.application.dto.TabDeleteServiceRequest;
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
 import com.example.planservice.domain.plan.Plan;
@@ -30,6 +32,7 @@ import com.example.planservice.presentation.dto.response.TabFindResponse;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class TabServiceTest {
     @Autowired
@@ -61,7 +64,8 @@ class TabServiceTest {
         // then
         assertThat(savedId).isNotNull();
 
-        Tab savedTab = tabRepository.findById(savedId).get();
+        Tab savedTab = tabRepository.findById(savedId)
+            .get();
         assertThat(savedTab)
             .extracting(Tab::getTitle, Tab::getPlan)
             .containsExactly(request.getTitle(), plan);
@@ -89,7 +93,8 @@ class TabServiceTest {
         Long savedId = tabService.create(member.getId(), request);
 
         // then
-        Tab newTab = tabRepository.findById(savedId).get();
+        Tab newTab = tabRepository.findById(savedId)
+            .get();
         assertThat(newTab.isFirst()).isFalse();
         assertThat(oldTab.isFirst()).isTrue();
     }
@@ -147,9 +152,11 @@ class TabServiceTest {
         // then
         assertThat(savedId).isNotNull();
 
-        Tab savedTab = tabRepository.findById(savedId).get();
+        Tab savedTab = tabRepository.findById(savedId)
+            .get();
         assertThat(savedTab.getTitle()).isEqualTo(request.getTitle());
-        assertThat(savedTab.getPlan().getId()).isEqualTo(request.getPlanId());
+        assertThat(savedTab.getPlan()
+            .getId()).isEqualTo(request.getPlanId());
     }
 
     @Test
@@ -160,11 +167,22 @@ class TabServiceTest {
         Member member = createMember();
         createMemberOfPlan(plan, member);
 
-        Tab tab1 = Tab.builder().first(true).plan(plan).build();
-        Tab tab2 = Tab.builder().plan(plan).build();
-        Tab tab3 = Tab.builder().plan(plan).build();
-        Tab tab4 = Tab.builder().plan(plan).build();
-        Tab tab5 = Tab.builder().plan(plan).build();
+        Tab tab1 = Tab.builder()
+            .first(true)
+            .plan(plan)
+            .build();
+        Tab tab2 = Tab.builder()
+            .plan(plan)
+            .build();
+        Tab tab3 = Tab.builder()
+            .plan(plan)
+            .build();
+        Tab tab4 = Tab.builder()
+            .plan(plan)
+            .build();
+        Tab tab5 = Tab.builder()
+            .plan(plan)
+            .build();
         tabRepository.saveAll(List.of(tab1, tab2, tab3, tab4, tab5));
 
         TabCreateRequest request = createTabCreateRequest(plan.getId(), "이름");
@@ -213,7 +231,8 @@ class TabServiceTest {
         // then
         assertThat(savedId).isNotNull();
 
-        Tab savedTab = tabRepository.findById(savedId).get();
+        Tab savedTab = tabRepository.findById(savedId)
+            .get();
         assertThat(tab2.getNext()).isEqualTo(savedTab);
         assertThat(savedTab.getNext()).isNull();
     }
@@ -450,7 +469,8 @@ class TabServiceTest {
         Long deletedId = tabService.delete(request);
 
         // then
-        Tab result = tabRepository.findById(deletedId).get();
+        Tab result = tabRepository.findById(deletedId)
+            .get();
         assertThat(result.isDeleted()).isTrue();
     }
 
@@ -629,7 +649,9 @@ class TabServiceTest {
 
     @NotNull
     private Task createTask(Tab tab) {
-        Task task = Task.builder().tab(tab).build();
+        Task task = Task.builder()
+            .tab(tab)
+            .build();
         em.persist(task);
         return task;
     }
@@ -661,7 +683,9 @@ class TabServiceTest {
 
     @NotNull
     private Plan createPlanWithOwner(Member owner) {
-        Plan plan = Plan.builder().owner(owner).build();
+        Plan plan = Plan.builder()
+            .owner(owner)
+            .build();
         em.persist(plan);
         return plan;
     }

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.planservice.application.dto.TaskUpdateServiceRequest;
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.label.Label;
 import com.example.planservice.domain.label.repository.LabelRepository;
 import com.example.planservice.domain.member.Member;
@@ -38,6 +40,7 @@ import com.example.planservice.presentation.dto.response.TaskFindResponse;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class TaskServiceTest {
     @Autowired
@@ -750,7 +753,10 @@ class TaskServiceTest {
         Task nextTask = createTaskWithTab(tab);
         Member member = createMemberWithPlan(plan);
         Label label1 = createLabelUsingTest(plan);
-        labelOfTaskRepository.save(LabelOfTask.builder().task(task).label(label1).build());
+        labelOfTaskRepository.save(LabelOfTask.builder()
+            .task(task)
+            .label(label1)
+            .build());
         em.flush();
         em.clear();
 

--- a/plan-service/src/test/java/com/example/planservice/application/dto/MemberRegisterResponseTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/dto/MemberRegisterResponseTest.java
@@ -6,13 +6,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.member.Member;
 import jakarta.persistence.EntityManager;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @Transactional
 class MemberRegisterResponseTest {

--- a/plan-service/src/test/java/com/example/planservice/config/TestConfig.java
+++ b/plan-service/src/test/java/com/example/planservice/config/TestConfig.java
@@ -1,0 +1,13 @@
+package com.example.planservice.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@TestConfiguration
+public class TestConfig {
+
+    @MockBean
+    private RedisTemplate<String, Object> redisTemplate;
+
+}

--- a/plan-service/src/test/java/com/example/planservice/domain/member/repository/MemberRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/member/repository/MemberRepositoryTest.java
@@ -1,20 +1,22 @@
 package com.example.planservice.domain.member.repository;
 
-import com.example.planservice.domain.member.Member;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
+import com.example.planservice.domain.member.Member;
+
 @SpringBootTest
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @Transactional
 class MemberRepositoryTest {
@@ -25,14 +27,17 @@ class MemberRepositoryTest {
     @DisplayName("이메일로 멤버를 찾는다")
     void testFindByEmailSuccess() {
         // given
-        Member member = Member.builder().email("a@naver.com").build();
+        Member member = Member.builder()
+            .email("a@naver.com")
+            .build();
         memberRepository.save(member);
 
         // when
         Optional<Member> resultOpt = memberRepository.findByEmail("a@naver.com");
 
         // then
-        assertThat(resultOpt.get().getId()).isEqualTo(member.getId());
+        assertThat(resultOpt.get()
+            .getId()).isEqualTo(member.getId());
     }
 
     @Test

--- a/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/memberofplan/repository/MemberOfPlanRepositoryTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.member.Member;
 import com.example.planservice.domain.member.repository.MemberRepository;
 import com.example.planservice.domain.memberofplan.MemberOfPlan;
@@ -19,6 +21,7 @@ import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class MemberOfPlanRepositoryTest {
     @Autowired

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/TabGroupTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.domain.tab.repository.TabRepository;
@@ -20,6 +22,7 @@ import com.example.planservice.exception.ApiException;
 import com.example.planservice.exception.ErrorCode;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class TabGroupTest {
     @Autowired
@@ -222,7 +225,8 @@ class TabGroupTest {
         Tab tab3 = createTab(plan, "탭3", tab2);
         Tab tab4 = createTab(plan, "탭4", tab3);
 
-        Tab addedTab = Tab.builder().build();
+        Tab addedTab = Tab.builder()
+            .build();
         TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4));
 
         // when
@@ -244,7 +248,8 @@ class TabGroupTest {
         Tab tab4 = createTab(plan, "탭4", tab3);
         Tab tab5 = createTab(plan, "탭5", tab4);
 
-        Tab addedTab = Tab.builder().build();
+        Tab addedTab = Tab.builder()
+            .build();
         TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1, tab2, tab3, tab4, tab5));
 
         // when & then
@@ -260,7 +265,9 @@ class TabGroupTest {
         Plan plan = createPlan();
         Tab tab1 = createTab(plan, "탭1", null);
 
-        Tab addedTab = Tab.builder().title("탭1").build();
+        Tab addedTab = Tab.builder()
+            .title("탭1")
+            .build();
         TabGroup tabGroup = new TabGroup(plan.getId(), List.of(tab1));
 
         // when & then
@@ -303,7 +310,8 @@ class TabGroupTest {
 
     @NotNull
     private Plan createPlan() {
-        Plan plan = Plan.builder().build();
+        Plan plan = Plan.builder()
+            .build();
         planRepository.save(plan);
         return plan;
     }

--- a/plan-service/src/test/java/com/example/planservice/domain/tab/repository/TabRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/tab/repository/TabRepositoryTest.java
@@ -8,13 +8,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.plan.Plan;
 import com.example.planservice.domain.plan.repository.PlanRepository;
 import com.example.planservice.domain.tab.Tab;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class TabRepositoryTest {
     @Autowired
@@ -27,20 +30,21 @@ class TabRepositoryTest {
     @DisplayName("플랜 아이디로 모든 Tab을 조회한다")
     void findAllByPlanId() {
         // given
-        final Plan plan = Plan.builder().build();
+        final Plan plan = Plan.builder()
+            .build();
         planRepository.save(plan);
 
         final Tab tab1 = Tab.builder()
-                            .title("탭1")
-                            .plan(plan)
-                            .build();
+            .title("탭1")
+            .plan(plan)
+            .build();
         final Tab tab2 = Tab.builder()
-                            .title("탭2")
-                            .plan(plan)
-                            .build();
+            .title("탭2")
+            .plan(plan)
+            .build();
         final Tab tab3 = Tab.builder()
-                            .title("탭3")
-                            .build();
+            .title("탭3")
+            .build();
         tabRepository.saveAll(List.of(tab1, tab2, tab3));
 
         // when
@@ -48,7 +52,7 @@ class TabRepositoryTest {
 
         // then
         assertThat(tabs).hasSize(2)
-                        .extracting("title")
-                        .contains("탭1", "탭2");
+            .extracting("title")
+            .contains("탭1", "탭2");
     }
 }

--- a/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/task/repository/TaskRepositoryTest.java
@@ -8,13 +8,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.planservice.config.TestConfig;
 import com.example.planservice.domain.tab.Tab;
 import com.example.planservice.domain.tab.repository.TabRepository;
 import com.example.planservice.domain.task.Task;
 
 @SpringBootTest
+@Import(TestConfig.class)
 @Transactional
 class TaskRepositoryTest {
     @Autowired
@@ -42,7 +45,8 @@ class TaskRepositoryTest {
     }
 
     private Tab createTab() {
-        Tab tab = Tab.builder().build();
+        Tab tab = Tab.builder()
+            .build();
         tabRepository.save(tab);
         return tab;
     }

--- a/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
+++ b/plan-service/src/test/java/com/example/planservice/interceptor/AuthenticationInterceptorTest.java
@@ -9,14 +9,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 
+import com.example.planservice.config.TestConfig;
+
 @SpringBootTest
+@Import(TestConfig.class)
 class AuthenticationInterceptorTest {
     AuthenticationInterceptor interceptor;
     MockHttpServletRequest request;

--- a/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/PlanControllerTest.java
@@ -154,7 +154,7 @@ class PlanControllerTest {
         Long userId = 1L;
         Long planId = 1L;
 
-        when(planService.inviteMember(planId, userId)).thenReturn(1L);
+        when(planService.inviteMember("uuid", userId)).thenReturn(1L);
 
         // when & then
         mockMvc.perform(put("/plans/invite/{planId}", planId)
@@ -170,7 +170,7 @@ class PlanControllerTest {
         Long userId = 1L;
         Long invalidPlanId = 9999L;
 
-        when(planService.inviteMember(invalidPlanId, userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
+        when(planService.inviteMember("uuid", userId)).thenThrow(new ApiException(ErrorCode.PLAN_NOT_FOUND));
 
         // when & then
         mockMvc.perform(put("/invite/{planId}", invalidPlanId)

--- a/plan-service/src/test/resources/application.yml
+++ b/plan-service/src/test/resources/application.yml
@@ -30,3 +30,4 @@ mail:
     enable: false
   username: sa
   password: 00
+service-url: http://localhost:8080


### PR DESCRIPTION
## 📌 Description
- 플랜 수정시 초대, 추방을 함께 할 수 있습니다.
- 플랜 초대시 중복 회원인지 검사
- 플랜 초대메일 발송시 uuid를 발송하고 uuid를 레디스에 저장합니다
- 플랜 invite API 시 uuid를 받고 레디스에 있는지 검증합니다.

## ⚠️ 주의사항
- Redis를 테스트시 Mock 하기 위해 모든 테스트  @Import(TestConfig.class) 를 넣어주었습니다. 좋은 방법이 아니란걸 알지만 embe다른 방법들을 시도하다가 여러 에러를 마주해서 최후의 보루로 이 방법을 채택하였습니다... 더 좋은 방안이 있다면 알려주시면 감사하겠습니다.  

close #104 
close #105 
