### PR TITLE
fix: 플랜 조회 시 500번 에러가 발생하는 이슈 해결

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -140,7 +140,7 @@ public class Tab extends BaseEntity {
     public List<Task> getSortedTasks() {
         List<Task> result = new ArrayList<>();
         Task temp = firstDummyTask;
-        while (!Objects.equals(lastDummyTask, temp.getNext())) {
+        while (!Objects.equals(lastDummyTask.getId(), temp.getNext().getId())) {
             temp = temp.getNext();
             result.add(temp);
         }


### PR DESCRIPTION
## 📌 Description
Task 엔티티간의 동등성 비교가 제대로 이뤄지지 않고 있었습니다.
우선은 Id를 비교하는 방식으로 문제를 해결했습니다.

## ⚠️ 주의사항
엔티티를 가져올 때, 영속성 관리가 되고 있는 엔티티라면 영속성 컨텍스트에서 가져옵니다.
저는 당연히 ID가 같으면 동일한 객체를 가져왔겠거니 생각했는데 그게 아니네요.
프록시 관련 문제이거나, 혹은 영속성에서 관리되지 않고 있는 이슈로 보입니다.
우선은 빠른 해결을 위해 ID를 비교하는 방식을 사용했습니다.

close #107 
