### PR TITLE
[#113, #114] Access-Control-Allow-Origin 헤더가 2개 생기는 오류를 해결했습니다.

### DIFF
--- a/auth-service/src/main/java/com/example/auth/config/WebConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.example.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowCredentials(false);
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
@@ -15,6 +15,7 @@ public class SecurityConfig {
         return http
             .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
             .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .cors(ServerHttpSecurity.CorsSpec::disable)
             .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
             .build();
     }

--- a/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/config/SecurityConfig.java
@@ -14,6 +14,7 @@ public class SecurityConfig {
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
         return http
             .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
             .build();
     }

--- a/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
+++ b/plan-service/src/main/java/com/example/planservice/config/WebConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -21,4 +22,10 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new AuthenticationInterceptor(pathMatcher()));
     }
 
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowCredentials(false);
+    }
 }


### PR DESCRIPTION
## 📌 Description
클라이언트가 요청을 보내면 Spring Cloud Gateway를 거쳐 하위 서버로 응답을 받아옵니다.
이 과정에서 Gateway랑 하위 서버 두 개를 거치면서 Access-Control-Allow-Origin 헤더가 2개 생기는 문제가 발생했습니다.
하위 서버에서 CORS를 해제하여 해당 문제를 해결했습니다.

추가로 [지난 PR](https://github.com/Side-Project-Planting/Backend/pull/110)에서 실수로 CSRF 설정을 해제해서 다시 disable 처리를 해주었습니다.

## ⚠️ 주의사항
<img width="676" alt="스크린샷 2023-11-28 오후 5 26 29" src="https://github.com/Side-Project-Planting/Backend/assets/67636607/45627940-565f-4e03-8117-02372dc2253a">
<br>
저는 Postman을 사용해서 CORS 검사를 했는데요.<br>
하위 서버를 직접 호출할 때, Origin 헤더의 값으로 localhost:3000을 넣고 테스트를 돌렸네요.(http://localhost:3000 를 넣어야해요)

잘못된 Origin 값을 보내서 Access-Control-Allow-Origin 이 생성되지 않았던건데,
Spring Cloud Gateway에서 설정이 중복되었다고 착각해서 시간을 낭비했네요.. 아쉽습니다.


close #113 
close #114 