### PR TITLE
[#119]YML 파일을 사용해 쿠키를 관리하도록 변경

### DIFF
--- a/auth-service/src/main/java/com/example/auth/config/ConfigurationPropertiesConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/ConfigurationPropertiesConfig.java
@@ -3,7 +3,8 @@ package com.example.auth.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import com.example.auth.oauth.google.GoogleProperties;
+import com.example.auth.presentation.CustomCookiesProperties;
 
-@EnableConfigurationProperties({GoogleProperties.class})
+@EnableConfigurationProperties({GoogleProperties.class, CustomCookiesProperties.class})
 public class ConfigurationPropertiesConfig {
 }

--- a/auth-service/src/main/java/com/example/auth/presentation/AuthController.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/AuthController.java
@@ -86,13 +86,7 @@ public class AuthController {
         if (refreshToken == null) {
             return;
         }
-        String cookieValue = cookieManager.createBuilder("refresh", refreshToken)
-            .httpOnly()
-            .secure()
-            .maxAge(60 * 60 * 24 * 30)
-            .path("/")
-            .sameSite("Strict")
-            .build();
+        String cookieValue = cookieManager.createRefreshToken(refreshToken);
         httpServletResponse.setHeader("Set-Cookie", cookieValue);
     }
 }

--- a/auth-service/src/main/java/com/example/auth/presentation/AuthController.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/AuthController.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AuthController {
     private final AuthService authService;
+    private final CustomCookieManager cookieManager;
 
     // TODO 삭제해야 하는 로직입니다.
     //  Auth Code를 확인하기 위해 임의로 설정한 URL입니다.
@@ -85,8 +86,13 @@ public class AuthController {
         if (refreshToken == null) {
             return;
         }
-        String cookieValue =
-            String.format("refresh=%s; Max-Age=%s; Path=/; HttpOnly; SameSite=Strict", refreshToken, 60 * 60 * 24 * 30);
+        String cookieValue = cookieManager.createBuilder("refresh", refreshToken)
+            .httpOnly()
+            .secure()
+            .maxAge(60 * 60 * 24 * 30)
+            .path("/")
+            .sameSite("Strict")
+            .build();
         httpServletResponse.setHeader("Set-Cookie", cookieValue);
     }
 }

--- a/auth-service/src/main/java/com/example/auth/presentation/CustomCookieManager.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/CustomCookieManager.java
@@ -1,5 +1,7 @@
 package com.example.auth.presentation;
 
+import static com.example.auth.presentation.CustomCookiesProperties.*;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -9,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class CustomCookieManager {
-    private final List<CustomCookiesProperties.CookieInfo> cookieInfos;
+    private final List<CookieInfo> cookieInfos;
 
     @Autowired
     public CustomCookieManager(CustomCookiesProperties customCookiesProperties) {
@@ -17,18 +19,21 @@ public class CustomCookieManager {
     }
 
     public String createRefreshToken(String refreshToken) {
-        CustomCookiesProperties.CookieInfo refreshCookieInfo = getCookieInfo("refresh");
+        return createCookieStr("refresh", refreshToken);
+    }
 
-        return createBuilder("refresh", refreshToken)
-            .httpOnly(refreshCookieInfo.isHttpOnly())
-            .secure(refreshCookieInfo.isSecure())
-            .maxAge(refreshCookieInfo.getMaxAge())
-            .path(refreshCookieInfo.getPath())
-            .sameSite(refreshCookieInfo.getSameSite())
+    public String createCookieStr(String name, String value) {
+        CookieInfo cookieInfo = getCookieInfo(name);
+        return createBuilder(cookieInfo.getName(), value)
+            .httpOnly(cookieInfo.isHttpOnly())
+            .secure(cookieInfo.isSecure())
+            .maxAge(cookieInfo.getMaxAge())
+            .path(cookieInfo.getPath())
+            .sameSite(cookieInfo.getSameSite())
             .build();
     }
 
-    private CustomCookiesProperties.CookieInfo getCookieInfo(String name) {
+    private CookieInfo getCookieInfo(String name) {
         return cookieInfos.stream()
             .filter(cookieInfo -> Objects.equals(cookieInfo.getName(), name))
             .findAny()

--- a/auth-service/src/main/java/com/example/auth/presentation/CustomCookieManager.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/CustomCookieManager.java
@@ -1,0 +1,77 @@
+package com.example.auth.presentation;
+
+import java.util.StringJoiner;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomCookieManager {
+
+    public Builder createBuilder(String name, String value) {
+        return new Builder(name, value);
+    }
+
+    public static class Builder {
+        private String name;
+
+        private String value;
+
+        private String sameSite;
+        private boolean httpOnly;
+        private String path;
+        private Integer maxAge;
+        private boolean secure;
+
+        public Builder(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public Builder sameSite(String sameSite) {
+            this.sameSite = sameSite;
+            return this;
+        }
+
+        public Builder httpOnly() {
+            this.httpOnly = true;
+            return this;
+        }
+
+        public Builder secure() {
+            this.secure = true;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder maxAge(Integer maxAge) {
+            this.maxAge = maxAge;
+            return this;
+        }
+
+        public String build() {
+            StringJoiner sj = new StringJoiner("; ");
+            sj.add(name + "=" + value);
+            if (maxAge != null) {
+                sj.add("Max-Age=" + maxAge);
+            }
+            if (path != null) {
+                sj.add("Path=" + path);
+            }
+            if (sameSite != null) {
+                sj.add("SameSite=" + sameSite);
+            }
+            if (httpOnly) {
+                sj.add("HttpOnly");
+            }
+            if (secure) {
+                sj.add("Secure");
+            }
+            return sj.toString();
+        }
+
+    }
+}

--- a/auth-service/src/main/java/com/example/auth/presentation/CustomCookiesProperties.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/CustomCookiesProperties.java
@@ -1,0 +1,33 @@
+package com.example.auth.presentation;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "custom-cookies")
+@Getter
+@Setter
+@Component
+public class CustomCookiesProperties {
+    private List<CookieInfo> cookieInfos;
+
+    @Getter
+    @Setter
+    public static class CookieInfo {
+        private String name;
+
+        private boolean httpOnly;
+
+        private boolean secure;
+
+        private int maxAge;
+
+        private String path;
+
+        private String sameSite;
+    }
+}

--- a/auth-service/src/main/java/com/example/auth/presentation/CustomCookiesProperties.java
+++ b/auth-service/src/main/java/com/example/auth/presentation/CustomCookiesProperties.java
@@ -24,7 +24,7 @@ public class CustomCookiesProperties {
 
         private boolean secure;
 
-        private int maxAge;
+        private Integer maxAge;
 
         private String path;
 

--- a/auth-service/src/test/java/com/example/auth/presentation/CustomCookieManagerTest.java
+++ b/auth-service/src/test/java/com/example/auth/presentation/CustomCookieManagerTest.java
@@ -1,0 +1,164 @@
+package com.example.auth.presentation;
+
+import static com.example.auth.presentation.CustomCookiesProperties.CookieInfo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CustomCookieManagerTest {
+
+    CustomCookiesProperties customCookiesProperties;
+    CustomCookieManager customCookieManager;
+
+    @BeforeEach
+    void setUp() {
+        customCookiesProperties = new CustomCookiesProperties();
+    }
+
+    @Test
+    @DisplayName("프로퍼티에 Refresh Token이 있으면 Refresh Token을 생성할 수 있다")
+    void testCreateRefreshToken() throws Exception {
+        // given
+        CookieInfo refreshCookieInfo = createCookieInfo("refresh");
+        customCookiesProperties.setCookieInfos(List.of(refreshCookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String refreshToken = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(refreshToken).startsWith("refresh=hello");
+    }
+
+    @Test
+    @DisplayName("HttpOnly 쿠키를 만든다")
+    void testCreateHttpOnlyCookie() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setHttpOnly(true);
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(token).startsWith("refresh=hello");
+        assertThat(token).contains("HttpOnly");
+    }
+
+    @Test
+    @DisplayName("Secure 쿠키를 만든다")
+    void testCreateSecureCookie() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setSecure(true);
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(token).startsWith("refresh=hello");
+        assertThat(token).contains("Secure");
+    }
+
+    @Test
+    @DisplayName("쿠키의 MaxAge를 지정한다")
+    void testCreateCookieWithMaxAgeOption() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setMaxAge(100000);
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(token).startsWith("refresh=hello");
+        assertThat(token).contains("Max-Age=" + cookieInfo.getMaxAge());
+    }
+
+    @Test
+    @DisplayName("쿠키의 Path를 지정한다")
+    void testCreateCookieWithPathOption() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setPath("/");
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(token).startsWith("refresh=hello");
+        assertThat(token).contains("Path=" + cookieInfo.getPath());
+    }
+
+    @Test
+    @DisplayName("쿠키의 SameSite를 지정한다")
+    void testCreateCookieWithSameSiteOption() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setSameSite("Strict");
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+
+        // then
+        assertThat(token).startsWith("refresh=hello");
+        assertThat(token).contains("SameSite=" + cookieInfo.getSameSite());
+    }
+
+    @Test
+    @DisplayName("쿠키의 각 속성은 세미 콜론으로 분리한다")
+    void testCreateCookie() throws Exception {
+        // given
+        CookieInfo cookieInfo = createCookieInfo("refresh");
+        cookieInfo.setSameSite("Strict");
+        cookieInfo.setSecure(true);
+        cookieInfo.setHttpOnly(true);
+        customCookiesProperties.setCookieInfos(List.of(cookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when
+        String token = customCookieManager.createRefreshToken("hello");
+        String[] values = token.split("; ");
+
+        // then
+        assertThat(values).contains("refresh=hello", "SameSite=Strict", "Secure", "HttpOnly");
+    }
+
+
+    @Test
+    @DisplayName("프로퍼티에 Refresh Token에 대한 정보를 입력하지 않았다면 Refresh Token을 생성할 수 없다")
+    void testCreateRefreshTokenFail() throws Exception {
+        // given
+        CookieInfo refreshCookieInfo = createCookieInfo("not-refresh");
+        customCookiesProperties.setCookieInfos(List.of(refreshCookieInfo));
+        customCookieManager = new CustomCookieManager(customCookiesProperties);
+
+        // when & then
+        assertThatThrownBy(() -> customCookieManager.createRefreshToken("hello"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("해당되는 이름의 토큰은 만들 수 없습니다");
+    }
+
+
+    private CookieInfo createCookieInfo(String name) {
+        CookieInfo cookieInfo = new CookieInfo();
+        cookieInfo.setName(name);
+        return cookieInfo;
+    }
+
+}


### PR DESCRIPTION
## 📌 Description
이제 YML 파일에 다음과 같은 값을 입력하여 쿠키를 만들 수 있습니다.
```
custom-cookies:
  cookieInfos:
    - name: refresh
      http-only: true
      secure: true
      max-age: 2592000 # 60초 * 60분 * 24시간 * 30일
      path: /
      same-site: Strict
```

### 변경한 이유
배포 서버에서 쿠키가 잘 만들어지지 않는 이슈가 있었습니다.
이유는 프론트엔드와 백엔드가 Cross Orign이며 Cross Site이기 때문입니다.

프론트엔드 도메인이 planting.vercel.app이고, 백엔드 도메인이 aaa.bbb.ccc입니다.
그래서 백엔드 서버로 요청을 보내면 Set-Cookie 헤더가 있음에도 브라우저가 프론트엔드에서 사용할 수 있는 쿠키를 만들어주지 못했습니다.

아무튼, 이 과정에서 쿠키를 테스트하느라 수도 없이 clean -> build를 반복하는 게 너무 귀찮았습니다.
그래서 다음번에는 쿠키 때문에 다시 빌드하는 일이 없도록 yml 파일에서 쿠키를 관리하도록 구조를 변경해버렸습니다.

## ⚠️ 주의사항
지금은 Same Site 를 None을 주어서 프론트엔드 도메인에서 백엔드 도메인으로 요청을 보낼 수 있게 만들었는데요.
이 부분 도메인 구매하고 나서 Strict로 다시 변경하겠습니다.

close #119
