### PR TITLE
[#123] Authorized Uri 요청을 localhost:3000에서 보낸 경우 redirect url에 localhost:3000을 넣어서 보내준다.

### DIFF
--- a/auth-service/src/main/java/com/example/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/example/auth/application/AuthService.java
@@ -46,10 +46,10 @@ public class AuthService {
      * 입력받은 providerName을 사용해 해당되는 OAuthProvider를 찾는다.
      * 반환된 OAuthProvider은 Authorized URL을 만들어 반환한다.
      */
-    public GetAuthorizedUriResponse getAuthorizedUri(String providerName) {
+    public String getAuthorizedUri(String providerName) {
         OAuthProvider oAuthProvider = oAuthProviderResolver.find(providerName);
         String state = randomStringFactory.create();
-        return new GetAuthorizedUriResponse(oAuthProvider.getAuthorizedUriWithParams(state));
+        return oAuthProvider.getAuthorizedUriWithParams(state);
     }
 
     /**

--- a/auth-service/src/test/java/com/example/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/example/auth/application/AuthServiceTest.java
@@ -96,10 +96,9 @@ class AuthServiceTest {
     @DisplayName("google의 AuthorizedUrl을 가져온다")
     void getGoogleAuthorizedUrl() {
         //when
-        final GetAuthorizedUriResponse response = authService.getAuthorizedUri("google");
+        String authorizedUrl = authService.getAuthorizedUri("google");
 
         // then
-        final String authorizedUrl = response.getAuthorizedUri();
         final String[] url = authorizedUrl.split("[?]");
         final String endpoint = url[0];
         final Map<String, String> params = extractParams(url[1]);

--- a/auth-service/src/test/java/com/example/auth/presentation/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/example/auth/presentation/AuthControllerTest.java
@@ -57,11 +57,10 @@ class AuthControllerTest {
     void getAuthorizedUri() throws Exception {
         // given
         String providerName = "google";
-        GetAuthorizedUriResponse response = new GetAuthorizedUriResponse("https://answer-uri");
 
         // stub
         when(authService.getAuthorizedUri(providerName))
-            .thenReturn(response);
+            .thenReturn("https://answer-uri");
 
         // when & then
         mockMvc.perform(get(String.format("/oauth/%s/authorized-uri", providerName)))


### PR DESCRIPTION
## 📌 Description
만약 요청이 localhost:3000으로 들어왔을 경우, AuthorizedUri의 redirect uri를 localhost:3000으로 변경해줍니다.

## ⚠️ 주의사항
프론트에서 localhost:3000으로도, planting.vercel.app으로도 테스트를 할 수 있게 바꿔달라는 요구사항이 들어왔습니다.

이유는 CORS 등을 테스트하기 위해 외부 환경에 있는 서버에 요청을 보내고 싶어서라고 합니다.
localhost:3000으로도 vercel로도 문제없이 테스트를 하고 싶다네요.
사실 가장 좋은 건 서버를 두 개 띄우는 건데요. 이건 비용 이슈로 할 수 없는 부분이라, 내부 로직을 건들게 되었습니다.

해당 요구사항을 만족하려면 아예 구조를 바꾸는 게 최선인데요.
저는 이로 인해 구조를 바꾸지 않는게 합리적이라는 생각이 들었습니다.(구조가 지저분해지더라도..)

왜냐하면 해당 요구사항은 지금에서만 적용되는 요구사항이라고 판단했기 때문입니다.
이후에 CORS 등 테스트를 끝내고 나면 localhost:3000에서 굳이 클라우드 환경으로 요청을 보낼 필요가 없다고 생각했기 때문입니다.
따라서 지금만 잠깐 사용하고, 나중에 폐기하기 위한 목적으로 구조를 변경하지 않았습니다.

close #123
