### PR TITLE
[#114]Access-Control-Allow-Origin 헤더가 2개 생기는 오류를 해결했습니다. -3차

### DIFF
--- a/auth-service/src/main/java/com/example/auth/interceptor/CorsInvalidateInterceptor.java
+++ b/auth-service/src/main/java/com/example/auth/interceptor/CorsInvalidateInterceptor.java
@@ -9,7 +9,7 @@ public class CorsInvalidateInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
         throws Exception {
-        response.setHeader("Access-Control-Allow-Origin", "");
+        response.setHeader("Access-Control-Allow-Origin", null);
     }
 
 

--- a/auth-service/src/main/java/com/example/auth/oauth/google/GoogleOAuthClient.java
+++ b/auth-service/src/main/java/com/example/auth/oauth/google/GoogleOAuthClient.java
@@ -67,7 +67,7 @@ public class GoogleOAuthClient implements OAuthClient {
         params.add("client_id", properties.getClientId());
         params.add("client_secret", properties.getClientSecret());
         params.add("code", authCode);
-        params.add("redirect_uri", "http://localhost:8443/login/oauth2/code/google");
+        params.add("redirect_uri", "http://localhost:3000/login/oauth2/code/google");
         params.add("grant_type", "authorization_code");
 
         HttpEntity<?> request = new HttpEntity<>(params, headers);

--- a/plan-service/src/main/java/com/example/planservice/interceptor/CorsInvalidateInterceptor.java
+++ b/plan-service/src/main/java/com/example/planservice/interceptor/CorsInvalidateInterceptor.java
@@ -9,7 +9,7 @@ public class CorsInvalidateInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
         throws Exception {
-        response.setHeader("Access-Control-Allow-Origin", "");
+        response.setHeader("Access-Control-Allow-Origin", null);
     }
 
 }


### PR DESCRIPTION
## 📌 Description
기존 필터에서는 Access-Control-Allow-Origin 헤더에 ""를 넣어줬는데, null을 넣어 해당 헤더를 없애는 방식으로 변경했습니다.

## ⚠️ 주의사항
### Access-Control-Allow-Origin 헤더가 선택적으로 삭제되던 이슈
기존에 몇 개의 요청(POST /oauth/{provider}/login, POST /plans... ) 은 헤더가 삭제되고,
몇 개의 URL(POST /tasks) 에서는 헤더가 삭제되지 않는 이슈가 있었는데요.

원인은 모르겠습니다. 인터셉터 적용 문제인가 한참을 디버깅했는데 논리 흐름이 동일합니다.
오히려 기존의 코드에서 헤더가 삭제되지 않았어야 했는데 왜 삭제됐던 건지를  모르겠습니다.

아무튼 현재 방식은 null을 넣어줌으로써, 해당 헤더를 삭제하는 방식으로 변경했습니다.

close #114
