### PR TITLE
[#127] 탭 삭제 시 발생하는 "태스크가 존재하지 않는다" 오류 해결

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/TabService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TabService.java
@@ -95,6 +95,7 @@ public class TabService {
 
         Tab target = tabGroup.findById(tabId);
         target.delete();
+        taskRepository.deleteAllByTabId(tabId);
         return tabId;
     }
 

--- a/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/tab/Tab.java
@@ -134,7 +134,6 @@ public class Tab extends BaseEntity {
 
     public void delete() {
         this.isDeleted = true;
-        tasks.forEach(Task::delete);
     }
 
     public List<Task> getSortedTasks() {

--- a/plan-service/src/main/java/com/example/planservice/domain/task/repository/TaskRepository.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/repository/TaskRepository.java
@@ -3,6 +3,8 @@ package com.example.planservice.domain.task.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.planservice.domain.task.Task;
@@ -10,4 +12,8 @@ import com.example.planservice.domain.task.Task;
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByTabId(Long tabId);
+
+    @Modifying
+    @Query("update Task t set t.isDeleted = true where t.tab.id = :tabId")
+    void deleteAllByTabId(Long tabId);
 }


### PR DESCRIPTION
## 📌 Description
### 기존 로직
tab의 삭제가 일어나면 task.delete()를 순차적으로 수행합니다.
이 때, firstTaskId, lastTaskId는 해당 메서드로 삭제할 수 없도록 막아둬서 위와 같은 문제가 발생했습니다.
### 변경
단순하게 taskRepository에 deleteAll 요청을 보냄으로써 문제를 해결했습니다.

## ⚠️ 주의사항
없습니다.

close #127 
