### PR TITLE
[#102, #130] 태스크 관련 이슈 해결

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -45,6 +45,8 @@ public class TaskService {
             .manager(assignee)
             .title(request.getTitle())
             .description(request.getDescription())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
             .build();
 
         Task savedTask = taskRepository.save(task);

--- a/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class TaskUpdateServiceRequest {
     private Long taskId;
     private Long memberId;
+    private Long assigneeId;
     private Long planId;
     private Long managerId;
     private String title;
@@ -24,11 +25,12 @@ public class TaskUpdateServiceRequest {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private TaskUpdateServiceRequest(Long taskId, Long memberId, Long planId, Long managerId, String title,
+    private TaskUpdateServiceRequest(Long taskId, Long memberId, Long assigneeId, Long planId, Long managerId, String title,
                                      String description, LocalDateTime startDate, LocalDateTime endDate,
                                      List<Long> labels) {
         this.taskId = taskId;
         this.memberId = memberId;
+        this.assigneeId = assigneeId;
         this.planId = planId;
         this.managerId = managerId;
         this.title = title;

--- a/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
@@ -1,6 +1,6 @@
 package com.example.planservice.application.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.example.planservice.domain.member.Member;
@@ -19,14 +19,14 @@ public class TaskUpdateServiceRequest {
     private Long managerId;
     private String title;
     private String description;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private List<Long> labels;
 
     @Builder
     @SuppressWarnings("java:S107")
     private TaskUpdateServiceRequest(Long taskId, Long memberId, Long assigneeId, Long planId, Long managerId, String title,
-                                     String description, LocalDateTime startDate, LocalDateTime endDate,
+                                     String description, LocalDate startDate, LocalDate endDate,
                                      List<Long> labels) {
         this.taskId = taskId;
         this.memberId = memberId;

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -1,6 +1,6 @@
 package com.example.planservice.domain.task;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,9 +57,9 @@ public class Task extends BaseEntity {
 
     private String description;
 
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     private boolean isDeleted;
 
@@ -76,8 +76,8 @@ public class Task extends BaseEntity {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private Task(Tab tab, Member manager, String title, String description, LocalDateTime startDate,
-                 LocalDateTime endDate, boolean isDeleted, Task next, Task prev, int version) {
+    private Task(Tab tab, Member manager, String title, String description, LocalDate startDate,
+                 LocalDate endDate, boolean isDeleted, Task next, Task prev, int version) {
         validateDates(startDate, endDate);
         this.tab = tab;
         this.assignee = manager;
@@ -199,7 +199,7 @@ public class Task extends BaseEntity {
         return next != null || prev != null;
     }
 
-    private void validateDates(LocalDateTime startDate, LocalDateTime endDate) {
+    private void validateDates(LocalDate startDate, LocalDate endDate) {
         if (startDate == null || endDate == null) {
             return;
         }
@@ -217,12 +217,12 @@ public class Task extends BaseEntity {
         if (isDateOver()) {
             return -1;
         }
-        return LocalDateTime.now()
+        return LocalDate.now()
             .compareTo(this.endDate);
     }
 
     public boolean isDateOver() {
-        return this.endDate == null || LocalDateTime.now()
+        return this.endDate == null || LocalDate.now()
             .isAfter(this.endDate);
     }
 }

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskCreateRequest.java
@@ -1,6 +1,6 @@
 package com.example.planservice.presentation.dto.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,10 +32,10 @@ public class TaskCreateRequest {
     private String description;
 
     @Schema(description = "추후에 날짜까지만 입력받도록 변경될 예정", nullable = true, example = "2023-11-08T08:00:00")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Schema(description = "추후에 날짜까지만 입력받도록 변경될 예정", nullable = true, example = "2023-11-09T08:00:00")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Schema(description = "만약 Null이 입력된다면 [] 가 대신 들어감", nullable = true, example = "[1,2,3]")
     private List<Long> labels;
@@ -43,7 +43,7 @@ public class TaskCreateRequest {
     @Builder
     @SuppressWarnings("java:S107")
     private TaskCreateRequest(Long planId, Long tabId, Long assigneeId, String title, String description,
-                              LocalDateTime startDate, LocalDateTime endDate, List<Long> labels) {
+                              LocalDate startDate, LocalDate endDate, List<Long> labels) {
         this.planId = planId;
         this.tabId = tabId;
         this.assigneeId = assigneeId;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.example.planservice.presentation.dto.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,18 +30,18 @@ public class TaskUpdateRequest {
     private String description;
 
     @Schema(description = "추후에 날짜까지만 입력받도록 변경될 예정", nullable = true, example = "2023-11-08T08:00:00")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Schema(description = "추후에 날짜까지만 입력받도록 변경될 예정", nullable = true, example = "2023-11-09T08:00:00")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Schema(description = "만약 Null이 입력된다면 [] 가 대신 들어감", nullable = true, example = "[1,2,3]")
     private List<Long> labels;
 
     @Builder
     @SuppressWarnings("java:S107")
-    private TaskUpdateRequest(Long planId, Long memberId, Long assigneeId, String title, String description, LocalDateTime startDate,
-                              LocalDateTime endDate, List<Long> labels) {
+    private TaskUpdateRequest(Long planId, Long memberId, Long assigneeId, String title, String description, LocalDate startDate,
+                              LocalDate endDate, List<Long> labels) {
         this.planId = planId;
         this.memberId = memberId;
         this.assigneeId = assigneeId;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskUpdateRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/request/TaskUpdateRequest.java
@@ -18,7 +18,9 @@ public class TaskUpdateRequest {
     @NotNull
     private Long planId;
 
-    private Long managerId;
+    private Long memberId;
+
+    private Long assigneeId;
 
     @NotBlank
     @Schema(nullable = false, example = "변경할 이름")
@@ -38,10 +40,11 @@ public class TaskUpdateRequest {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private TaskUpdateRequest(Long planId, Long managerId, String title, String description, LocalDateTime startDate,
+    private TaskUpdateRequest(Long planId, Long memberId, Long assigneeId, String title, String description, LocalDateTime startDate,
                               LocalDateTime endDate, List<Long> labels) {
         this.planId = planId;
-        this.managerId = managerId;
+        this.memberId = memberId;
+        this.assigneeId = assigneeId;
         this.title = title;
         this.description = description;
         this.startDate = startDate;
@@ -52,9 +55,9 @@ public class TaskUpdateRequest {
     public TaskUpdateServiceRequest toServiceRequest(@NotNull Long memberId, @NotNull Long taskId) {
         return TaskUpdateServiceRequest.builder()
             .taskId(taskId)
-            .memberId(memberId)
             .planId(planId)
-            .managerId(managerId)
+            .memberId(memberId)
+            .assigneeId(assigneeId)
             .title(title)
             .description(description)
             .startDate(startDate)

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
@@ -1,6 +1,6 @@
 package com.example.planservice.presentation.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,10 +32,10 @@ public class TaskFindResponse {
     private String description;
 
     @Schema(description = "추후에 날짜까지만 보내줄 예정", nullable = true, example = "2023-11-08T08:00:00")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Schema(description = "추후에 날짜까지만 보내줄 예정", nullable = true, example = "2023-11-09T08:00:00")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     private Long nextId;
 
@@ -44,7 +44,7 @@ public class TaskFindResponse {
     @Builder
     @SuppressWarnings("java:S107")
     public TaskFindResponse(Long id, Long tabId, Long planId, Long managerId, List<Long> labels, String title,
-                            String description, LocalDateTime startDate, LocalDateTime endDate, Long nextId,
+                            String description, LocalDate startDate, LocalDate endDate, Long nextId,
                             Long prevId) {
         this.id = id;
         this.tabId = tabId;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskOfPlanResponse.java
@@ -1,6 +1,6 @@
 package com.example.planservice.presentation.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.example.planservice.domain.task.Task;
@@ -16,12 +16,12 @@ public class TaskOfPlanResponse {
     private List<Long> labels;
     private Long tabId;
     private Long assigneeId;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     @Builder
     private TaskOfPlanResponse(Long id, String title, Long tabId, List<Long> labels, Long assigneeId,
-                               LocalDateTime startDate, LocalDateTime endDate) {
+                               LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.title = title;
         this.labels = labels;

--- a/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/PlanServiceTest.java
@@ -575,8 +575,8 @@ class PlanServiceTest {
             .title(title)
             .tabId(tabId)
             .planId(planId)
-            .startDate(LocalDate.now().atStartOfDay())
-            .endDate(LocalDate.now().plusDays(days).atStartOfDay())
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(days))
             .build();
         Long taskId = taskService.create(memberId, request);
         return taskRepository.findById(taskId).get();

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -3,7 +3,7 @@ package com.example.planservice.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -554,9 +554,9 @@ class TaskServiceTest {
             .managerId(taskManager.getId())
             .title("변경된 이름")
             .description("이렇게 설명할게요")
-            .startDate(LocalDateTime.now()
+            .startDate(LocalDate.now()
                 .minusDays(10))
-            .endDate(LocalDateTime.now()
+            .endDate(LocalDate.now()
                 .plusDays(2))
             .labels(List.of(label1.getId(), label2.getId()))
             .build();
@@ -610,9 +610,9 @@ class TaskServiceTest {
             .managerId(null)
             .title("변경된 이름")
             .description("이렇게 설명할게요")
-            .startDate(LocalDateTime.now()
+            .startDate(LocalDate.now()
                 .minusDays(10))
-            .endDate(LocalDateTime.now()
+            .endDate(LocalDate.now()
                 .plusDays(2))
             .labels(List.of(label1.getId(), label2.getId()))
             .build();

--- a/plan-service/src/test/java/com/example/planservice/domain/task/TaskTest.java
+++ b/plan-service/src/test/java/com/example/planservice/domain/task/TaskTest.java
@@ -3,7 +3,7 @@ package com.example.planservice.domain.task;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
@@ -36,8 +36,8 @@ class TaskTest {
     @DisplayName("태스크의 startDate는 endDate보다 빨라야 합니다")
     void testDateIsValid() throws Exception {
         // given
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.plusDays(1);
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.plusDays(1);
 
         // when & then
         assertThatThrownBy(() -> createTask(startDate, endDate))
@@ -45,7 +45,7 @@ class TaskTest {
             .hasMessageContaining(ErrorCode.TASK_DATE_INVALID.getMessage());
     }
 
-    private Task createTask(LocalDateTime startDate, LocalDateTime endDate) {
+    private Task createTask(LocalDate startDate, LocalDate endDate) {
         return Task.builder()
             .startDate(startDate)
             .endDate(endDate)


### PR DESCRIPTION
## 📌 Description
1. 태스크를 수정할 때 assignee가 null로 등록되는 이슈가 있었습니다.
해당 필드가 누락되어 발생한 이슈로 필드를 추가해주었습니다.

2. 사용자가 Task를 등록할 때, 날짜만을 입력받도록 변경해줬습니다.
기존에는 시간-분-초를 함께 입력해야 했는데 타입을 LocalDate로 변경함으로써 날짜만을 입력받도록 변경해줬습니다.

3. 사용자의 입력값이 잘못되었을 때, 어떤 필드에서 발생한 오류인지 함께 보여주도록 구현했습니다.

## ⚠️ 주의사항
없습니다.

close #102 
close #130 
