### PR TITLE
[#133] 리소스를 생성하는데 성공했을 경우, ID 값을 반환하도록 변경

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/LabelController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.planservice.application.LabelService;
 import com.example.planservice.application.dto.LabelDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.LabelCreateRequest;
+import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.LabelFindResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,10 +34,11 @@ public class LabelController {
 
     @PostMapping
     @ApiResponse(responseCode = "201", description = "라벨 생성 성공")
-    ResponseEntity<Void> create(@RequestBody @Valid LabelCreateRequest labelCreateRequest,
-                                @RequestAttribute Long userId) {
+    ResponseEntity<CreateResponse> create(@RequestBody @Valid LabelCreateRequest labelCreateRequest,
+                                          @RequestAttribute Long userId) {
         Long createdId = labelService.create(userId, labelCreateRequest);
-        return ResponseEntity.created(URI.create("/labels/" + createdId)).build();
+        return ResponseEntity.created(URI.create("/labels/" + createdId))
+            .body(CreateResponse.of(createdId));
     }
 
     @DeleteMapping("/{id}")

--- a/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TabController.java
@@ -21,6 +21,7 @@ import com.example.planservice.application.dto.TabDeleteServiceRequest;
 import com.example.planservice.presentation.dto.request.TabChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TabChangeTitleRequest;
 import com.example.planservice.presentation.dto.request.TabCreateRequest;
+import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.TabChangeOrderResponse;
 import com.example.planservice.presentation.dto.response.TabFindResponse;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,10 +40,11 @@ public class TabController {
 
     @PostMapping
     @ApiResponse(responseCode = "201", description = "탭 생성 성공")
-    public ResponseEntity<Void> create(@Valid @RequestBody TabCreateRequest request,
-                                       @RequestAttribute Long userId) {
+    public ResponseEntity<CreateResponse> create(@Valid @RequestBody TabCreateRequest request,
+                                                 @RequestAttribute Long userId) {
         Long createdId = tabService.create(userId, request);
-        return ResponseEntity.created(URI.create("/tabs/" + createdId)).build();
+        return ResponseEntity.created(URI.create("/tabs/" + createdId))
+            .body(CreateResponse.of(createdId));
     }
 
     @PostMapping("/change-order")

--- a/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/TaskController.java
@@ -18,6 +18,7 @@ import com.example.planservice.application.TaskService;
 import com.example.planservice.presentation.dto.request.TaskChangeOrderRequest;
 import com.example.planservice.presentation.dto.request.TaskCreateRequest;
 import com.example.planservice.presentation.dto.request.TaskUpdateRequest;
+import com.example.planservice.presentation.dto.response.CreateResponse;
 import com.example.planservice.presentation.dto.response.TaskFindResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,10 +37,11 @@ public class TaskController {
 
     @PostMapping
     @ApiResponse(responseCode = "201", description = "태스크 생성 성공")
-    public ResponseEntity<Void> create(@RequestBody @Valid TaskCreateRequest request,
-                                       @RequestAttribute Long userId) {
+    public ResponseEntity<CreateResponse> create(@RequestBody @Valid TaskCreateRequest request,
+                                                 @RequestAttribute Long userId) {
         Long createdId = taskService.create(userId, request);
-        return ResponseEntity.created(URI.create("/tasks/" + createdId)).build();
+        return ResponseEntity.created(URI.create("/tasks/" + createdId))
+            .body(CreateResponse.of(createdId));
     }
 
     @PutMapping("/{taskId}")

--- a/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/LabelControllerTest.java
@@ -54,7 +54,8 @@ class LabelControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
-            .andExpect(header().string("Location", "/labels/" + createdLabelId));
+            .andExpect(header().string("Location", "/labels/" + createdLabelId))
+            .andExpect(jsonPath("$.id").value(createdLabelId));
     }
 
     @Test

--- a/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TabControllerTest.java
@@ -63,7 +63,8 @@ class TabControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
-            .andExpect(header().string("Location", "/tabs/" + createdTabId));
+            .andExpect(header().string("Location", "/tabs/" + createdTabId))
+            .andExpect(jsonPath("$.id").value(createdTabId));
     }
 
     @Test

--- a/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
+++ b/plan-service/src/test/java/com/example/planservice/presentation/TaskControllerTest.java
@@ -54,7 +54,8 @@ class TaskControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", "/tasks/" + createdId))
-            .andExpect(redirectedUrlPattern("/tasks/*"));
+            .andExpect(redirectedUrlPattern("/tasks/*"))
+            .andExpect(jsonPath("$.id").value(createdId));;
     }
 
     @Test


### PR DESCRIPTION
## 📌 Description
Label, Tab, Task 리소스의 경우, 생성에 성공했을 때 Body에 아무 값도 내려주지 않고 있었습니다.
프론트 편의를 위해 ID값을 리턴하도록 변경해줬습니다.

## ⚠️ 주의사항
없습니다.

close #133 
