### PR TITLE
[#134] 태스크 수정 시 assigneeId 사라지는 이슈

### DIFF
--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -60,9 +60,9 @@ public class TaskService {
         Plan plan = planMembershipService.getPlanAfterValidateAuthorization(request.getPlanId(), request.getMemberId());
         Task task = taskRepository.findById(request.getTaskId())
             .orElseThrow(() -> new ApiException(ErrorCode.TASK_NOT_FOUND));
-        Member manager = getMember(request.getManagerId(), plan);
+        Member assignee = getMember(request.getAssigneeId(), plan);
 
-        task.change(request.toEntity(manager));
+        task.change(request.toEntity(assignee));
         List<LabelOfTask> labelOfTaskList = labelOfTaskRepository.findAllByTaskId(task.getId());
         labelOfTaskRepository.deleteAllInBatch(labelOfTaskList);
         saveAllLabelOfTask(request.getLabels(), task, plan);

--- a/plan-service/src/main/java/com/example/planservice/application/TaskService.java
+++ b/plan-service/src/main/java/com/example/planservice/application/TaskService.java
@@ -42,7 +42,7 @@ public class TaskService {
 
         Task task = Task.builder()
             .tab(tab)
-            .manager(assignee)
+            .assignee(assignee)
             .title(request.getTitle())
             .description(request.getDescription())
             .startDate(request.getStartDate())

--- a/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
@@ -16,7 +16,6 @@ public class TaskUpdateServiceRequest {
     private Long memberId;
     private Long assigneeId;
     private Long planId;
-    private Long managerId;
     private String title;
     private String description;
     private LocalDate startDate;
@@ -25,14 +24,13 @@ public class TaskUpdateServiceRequest {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private TaskUpdateServiceRequest(Long taskId, Long memberId, Long assigneeId, Long planId, Long managerId, String title,
+    private TaskUpdateServiceRequest(Long taskId, Long memberId, Long assigneeId, Long planId, String title,
                                      String description, LocalDate startDate, LocalDate endDate,
                                      List<Long> labels) {
         this.taskId = taskId;
         this.memberId = memberId;
-        this.assigneeId = assigneeId;
         this.planId = planId;
-        this.managerId = managerId;
+        this.assigneeId = assigneeId;
         this.title = title;
         this.description = description;
         this.startDate = startDate;

--- a/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
+++ b/plan-service/src/main/java/com/example/planservice/application/dto/TaskUpdateServiceRequest.java
@@ -38,9 +38,9 @@ public class TaskUpdateServiceRequest {
         this.labels = labels;
     }
 
-    public Task toEntity(Member manager) {
+    public Task toEntity(Member assignee) {
         return Task.builder()
-            .manager(manager)
+            .assignee(assignee)
             .title(title)
             .description(description)
             .startDate(startDate)

--- a/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
+++ b/plan-service/src/main/java/com/example/planservice/domain/task/Task.java
@@ -76,11 +76,11 @@ public class Task extends BaseEntity {
 
     @Builder
     @SuppressWarnings("java:S107")
-    private Task(Tab tab, Member manager, String title, String description, LocalDate startDate,
+    private Task(Tab tab, Member assignee, String title, String description, LocalDate startDate,
                  LocalDate endDate, boolean isDeleted, Task next, Task prev, int version) {
         validateDates(startDate, endDate);
         this.tab = tab;
-        this.assignee = manager;
+        this.assignee = assignee;
         this.title = title;
         this.description = description;
         this.startDate = startDate;

--- a/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
+++ b/plan-service/src/main/java/com/example/planservice/presentation/dto/response/TaskFindResponse.java
@@ -20,7 +20,7 @@ public class TaskFindResponse {
 
     private Long planId;
 
-    private Long managerId;
+    private Long assigneeId;
 
     @Schema(nullable = false, example = "[1,3,2]")
     private List<Long> labels;
@@ -43,13 +43,13 @@ public class TaskFindResponse {
 
     @Builder
     @SuppressWarnings("java:S107")
-    public TaskFindResponse(Long id, Long tabId, Long planId, Long managerId, List<Long> labels, String title,
+    public TaskFindResponse(Long id, Long tabId, Long planId, Long assigneeId, List<Long> labels, String title,
                             String description, LocalDate startDate, LocalDate endDate, Long nextId,
                             Long prevId) {
         this.id = id;
         this.tabId = tabId;
         this.planId = planId;
-        this.managerId = managerId;
+        this.assigneeId = assigneeId;
         this.labels = labels;
         this.title = title;
         this.description = description;
@@ -81,7 +81,7 @@ public class TaskFindResponse {
             .tabId(tab.getId())
             .planId(tab.getPlan()
                 .getId())
-            .managerId(task.getAssignee() != null ? task.getAssignee()
+            .assigneeId(task.getAssignee() != null ? task.getAssignee()
                 .getId() : null)
             .labels(labels)
             .title(task.getTitle())

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -530,7 +530,7 @@ class TaskServiceTest {
         Plan plan = createPlan();
         Tab tab = createTab(plan);
         Member loginMember = createMemberWithPlan(plan);
-        Member taskManager = createMemberWithPlan(plan);
+        Member assignee = createMemberWithPlan(plan);
         Task task = createTaskWithTab(tab);
         Label label1 = Label.builder()
             .plan(plan)
@@ -551,7 +551,7 @@ class TaskServiceTest {
             .taskId(task.getId())
             .memberId(loginMember.getId())
             .planId(plan.getId())
-            .managerId(taskManager.getId())
+            .assigneeId(assignee.getId())
             .title("변경된 이름")
             .description("이렇게 설명할게요")
             .startDate(LocalDate.now()
@@ -571,7 +571,7 @@ class TaskServiceTest {
         assertThat(updatedTask)
             .extracting(Task::getTab, Task::getAssignee, Task::getTitle,
                 Task::getDescription, Task::getStartDate, Task::getEndDate)
-            .containsExactly(tab, taskManager, request.getTitle(),
+            .containsExactly(tab, assignee, request.getTitle(),
                 request.getDescription(), request.getStartDate(), request.getEndDate());
 
         List<LabelOfTask> labelOfTaskList = labelOfTaskRepository.findAllByTaskId(updatedId);
@@ -607,7 +607,7 @@ class TaskServiceTest {
             .taskId(task.getId())
             .memberId(loginMember.getId())
             .planId(plan.getId())
-            .managerId(null)
+            .assigneeId(null)
             .title("변경된 이름")
             .description("이렇게 설명할게요")
             .startDate(LocalDate.now()

--- a/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
+++ b/plan-service/src/test/java/com/example/planservice/application/TaskServiceTest.java
@@ -770,6 +770,23 @@ class TaskServiceTest {
     }
 
     @Test
+    @DisplayName("태스크 조회 시 Description을 조회할 수 있다")
+    void testCanShowDescriptionThatCreateTask() throws Exception {
+        // given
+        Plan plan = createPlan();
+        Tab tab = createTab(plan);
+        Member member = createMemberWithPlan(plan);
+        Task task = createTaskWithTabAndDescription(tab, "설명임");
+        Task nextTask = createTaskWithTab(tab);
+
+        // when
+        TaskFindResponse response = taskService.find(task.getId(), member.getId());
+
+        // then
+        assertThat(response.getDescription()).isEqualTo(task.getDescription());
+    }
+
+    @Test
     @DisplayName("Private Plan에 속한 태스크는 가입된 사람만 볼 수 있다")
     void testFindTaskFailNotRegistered() throws Exception {
         // given
@@ -810,6 +827,19 @@ class TaskServiceTest {
         taskRepository.save(task);
         return task;
     }
+
+    private Task createTaskWithTabAndDescription(Tab tab, String description) {
+        Task task = Task.builder()
+            .description(description)
+            .tab(tab)
+            .build();
+        Task lastDummy = tab.getLastDummyTask();
+        lastDummy.putInFront(task);
+
+        taskRepository.save(task);
+        return task;
+    }
+
 
     private Plan createPlan() {
         Plan plan = Plan.builder()


### PR DESCRIPTION
## 📌 Description
태스크를 수정하면 기존에 존재하던 assigneeId가 무조건 null이 되는 이슈를 확인했습니다.
내부를 확인해보니 업데이트 시 리퀘스트 DTO 안에 manager 필드가 assignee 대신 적용되고 있더라구요.
manager 관련한 정보들을 assignee로 변경해주었습니다.

## ⚠️ 주의사항
없습니다.

close #134 
